### PR TITLE
Ignore intermediate paper.html from pandoc conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ benchmarks/contradictions-200/results.json
 benchmarks/**/__pycache__/
 
 benchmarks/repeat-mistake/logs/
+benchmarks/repeat-mistake/paper.html


### PR DESCRIPTION
Adds benchmarks/repeat-mistake/paper.html to .gitignore. The HTML is an intermediate output during pandoc markdown to PDF conversion; only the .md source and .pdf output need to be tracked. Tiny hygiene fix.