### PR TITLE
v0.10 prep: lock multi-seed replication plan + aggregator

### DIFF
--- a/benchmarks/repeat-mistake/SEED_PLAN.md
+++ b/benchmarks/repeat-mistake/SEED_PLAN.md
@@ -1,0 +1,134 @@
+# Multi-seed replication plan for v0.9 SWE-bench Verified benchmark
+
+**Locked:** 2026-06-25 (before any additional seed runs)
+**Parent methodology:** [`DESIGN.md`](./DESIGN.md) (locked 2026-06-17)
+**Parent result:** [`RESULTS.md`](./RESULTS.md) (v0.9.1 shipped 2026-06-24)
+**Author:** Saravanan Jaichandaran
+
+This plan locks the multi-seed replication strategy before any additional seed run kicks off. The v0.9.1 ship was single-trial (seed 1). This plan adds seeds 2 and 3 on a deliberately-chosen subset to test whether the v0.9 result reproduces under model sampling variance.
+
+## Why a subset, not a full re-run
+
+A full 3-seed run of all 49 paired instances would cost approximately 60 hours of agent wall-clock and 180 USD. A targeted subset captures the load-bearing data points (the flips that drove the +10.2 pts headline) plus variance-floor samples (stable outcomes that establish the variance baseline), at approximately 25 percent of the cost.
+
+The subset is locked here BEFORE any seed-2 run executes, so the subset selection cannot be moved post hoc to favor a particular outcome.
+
+## What sampling variance means in this benchmark
+
+Claude Code CLI does not expose `--seed` or `--temperature` flags. The Anthropic API uses sampling with temperature > 0 by default. Re-running the same (task, arm) combination produces a different patch each time because the model samples its output stochastically. "Multi-seed" here means "re-run twice more to observe model sampling variance" — not seed-controlled determinism.
+
+## Subset selection (17 instances, locked)
+
+Three categories:
+
+**A. Load-bearing flips and regressions (7 instances)** — the data points that drove the v0.9 headline numbers. If these reproduce across seeds, the headline holds. If not, the headline weakens.
+
+- `django__django-11400` (Subset 1 FAIL-to-PASS flip)
+- `django__django-13212` (Subset 1 FAIL-to-PASS flip)
+- `django__django-13344` (Subset 1 FAIL-to-PASS flip, recovered from empty patch in baseline)
+- `sympy__sympy-16597` (Subset 1 FAIL-to-PASS flip)
+- `sympy__sympy-17630` (Subset 1 PASS-to-FAIL regression)
+- `scikit-learn__scikit-learn-14087` (Subset 2 cross-domain FAIL-to-PASS flip)
+- `sphinx-doc__sphinx-9461` (Subset 2 cross-domain FAIL-to-PASS flip, cleanest mechanistic case)
+
+**B. Unchanged-PASS variance floor (5 instances)** — establish how often "stable PASS" instances remain PASS across re-runs. One per repository for coverage.
+
+- `django__django-10554`
+- `sympy__sympy-11618`
+- `matplotlib__matplotlib-14623`
+- `scikit-learn__scikit-learn-10297`
+- `sphinx-doc__sphinx-10466`
+
+**C. Unchanged-FAIL variance floor (5 instances)** — establish how often "stable FAIL" instances remain FAIL across re-runs.
+
+- `sympy__sympy-12489`
+- `matplotlib__matplotlib-22865`
+- `matplotlib__matplotlib-23314`
+- `sphinx-doc__sphinx-7590`
+- `sphinx-doc__sphinx-7748`
+
+Total: 17 instances × 2 arms (baseline, treatment) × 2 additional seeds = 68 task-runs.
+
+## Variance metrics to compute
+
+After seed 2 and seed 3 runs complete and scoring is done, compute the following for each (instance, arm) combination across the 3 seeds:
+
+1. **Pass rate**: fraction of seeds in which the instance passed (0, 1/3, 2/3, or 1).
+2. **Stability classification**:
+   - `stable_pass` — passed in all 3 seeds
+   - `stable_fail` — failed in all 3 seeds
+   - `flaky` — sometimes passed, sometimes failed across the 3 seeds
+3. **Per-arm aggregate**: number of stable_pass, stable_fail, and flaky instances per arm.
+
+Then compute per (instance) the paired delta across seeds:
+
+4. **Per-instance paired delta** — for each instance, count seeds where treatment passed minus seeds where baseline passed. Range: -3 to +3.
+5. **Mean paired delta across the 17 instances** — should approximately reproduce the v0.9 per-instance delta direction.
+6. **Bootstrap 95 percent confidence interval** on the mean paired delta — published as the headline replication number.
+
+## Interpretation thresholds (locked before re-runs)
+
+Replication is judged on whether the seed-2 and seed-3 outcomes match the seed-1 outcomes for the 7 load-bearing flips and regression.
+
+- **Strong replication**: at least 5 of the 7 load-bearing instances show the same direction as seed 1 in both seed 2 and seed 3 (treatment passed when v0.9 showed flip; treatment failed when v0.9 showed regression). The v0.9 headline holds.
+- **Moderate replication**: 3 or 4 of the 7 reproduce direction. The v0.9 headline is consistent with a real effect but with wider confidence bounds. Report as such.
+- **Weak replication**: 2 or fewer reproduce direction. The v0.9 headline is at risk of being single-trial variance. Honest negative update to RESULTS.md.
+
+The variance-floor samples (categories B and C) are not part of the replication judgment. They are used only to characterize the noise floor of the benchmark.
+
+## Acceptance criteria for publishing the multi-seed update
+
+Either of the following is sufficient to ship a v0.9.2 documentation patch with multi-seed results:
+
+A. Strong or moderate replication observed. RESULTS.md adds a "Multi-seed replication" section with mean ± std and bootstrap CI on the 17-instance subset.
+
+B. Weak replication observed. RESULTS.md adds a "Multi-seed replication" section with the same data, honestly framed as updating the confidence bounds on the v0.9 headline. The cross-domain regression-rate-of-zero finding (already listed as the most fragile in v0.9 limitations) is the most likely candidate for the update.
+
+We will NOT:
+- Move the subset boundary post hoc to favor an outcome
+- Cherry-pick which seed to report
+- Reframe the v0.9 result without publishing the multi-seed data verbatim
+
+## Implementation
+
+Each seed run uses the existing `orchestrator.py` with the `--instance-ids` and `--progress-suffix` flags:
+
+```
+# Seed 2 baseline
+python orchestrator.py --arm baseline \
+    --instance-ids [17-instance list] \
+    --progress-suffix "_seed2"
+
+# Seed 2 treatment
+python orchestrator.py --arm treatment \
+    --constraints constraints.json \
+    --instance-ids [17-instance list] \
+    --progress-suffix "_seed2_treatment"
+```
+
+Same for seed 3, with suffix `_seed3` / `_seed3_treatment`.
+
+For Subset 2 cross-domain (which uses only Subset 1 constraints), use the same `--constraints constraints.json` flag — this matches the v0.9 treatment-arm configuration exactly.
+
+Aggregation is handled by `multi_seed_aggregate.py` which loads the seed-1 (existing), seed-2, and seed-3 progress and results JSONLs and computes the metrics defined above.
+
+## Cost estimate
+
+- Per seed: 17 × 2 arms × ~30 min avg = ~17 hours agent wall-clock, ~$30 in agent cost
+- Two additional seeds: ~34 hours, ~$60 total
+- Scoring on cached env images: ~5-8 hours per seed (all env images already cached from v0.9)
+- Total wall-clock: approximately 50-60 hours spread over 3-5 days, depending on overnight runs
+- Total cost: approximately $60 USD on a Claude Code subscription
+
+## Output
+
+A v0.9.2 documentation patch with:
+- `multi_seed_progress.jsonl` (combined seed 1, 2, 3 progress data)
+- `multi_seed_results.jsonl` (combined seed 1, 2, 3 score data)
+- `multi_seed_summary.json` (variance metrics, stability classification, bootstrap CI)
+- Appendix in `RESULTS.md` titled "Multi-seed replication on 17-instance subset" with the headline number and the interpretation
+- Updated Zenodo preprint (v2)
+
+## Honesty commitment
+
+This plan is locked. No changes to the subset selection, the metrics, or the interpretation thresholds will be made after seed-2 runs begin. If a change is needed before the runs start (for example, a bug in the orchestrator), it will be documented in this file with the date of change and the reason.

--- a/benchmarks/repeat-mistake/multi_seed_aggregate.py
+++ b/benchmarks/repeat-mistake/multi_seed_aggregate.py
@@ -1,0 +1,323 @@
+"""
+Aggregate multi-seed runs of the v0.9 SWE-bench Verified benchmark.
+
+Loads progress/results JSONLs from seed 1 (the existing v0.9 data) plus any
+additional seeds (seed 2, seed 3, ...) and computes the variance metrics
+defined in SEED_PLAN.md:
+
+  - Per-instance pass rate across seeds (0, 1/3, 2/3, 1)
+  - Per-instance stability classification (stable_pass, stable_fail, flaky)
+  - Per-instance paired delta (treatment_passes - baseline_passes across seeds)
+  - Mean paired delta across the load-bearing subset
+  - Bootstrap 95% CI on the mean paired delta
+
+The smart subset is locked in SEED_PLAN.md. This script trusts that lock —
+it loads the same 17 instance IDs by default, but accepts a custom subset
+via --instance-ids if needed for a follow-up analysis.
+
+Usage:
+    python multi_seed_aggregate.py \\
+        --seed1-baseline baseline_results.jsonl \\
+        --seed1-baseline-s2 baseline_results_s2.jsonl \\
+        --seed1-treatment treatment_results_s1.jsonl \\
+        --seed1-treatment-s2 treatment_results_s2_crossdomain.jsonl \\
+        --seed2-baseline baseline_results_seed2.jsonl \\
+        --seed2-treatment treatment_results_seed2_treatment.jsonl \\
+        --seed3-baseline baseline_results_seed3.jsonl \\
+        --seed3-treatment treatment_results_seed3_treatment.jsonl \\
+        --out multi_seed_summary.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Optional
+
+# The 17 instances locked in SEED_PLAN.md. Categories matter for the
+# replication interpretation.
+SMART_SUBSET: dict[str, str] = {
+    # Load-bearing flips and regressions (7)
+    "django__django-11400": "load_bearing_flip",
+    "django__django-13212": "load_bearing_flip",
+    "django__django-13344": "load_bearing_flip",
+    "sympy__sympy-16597": "load_bearing_flip",
+    "sympy__sympy-17630": "load_bearing_regression",
+    "scikit-learn__scikit-learn-14087": "load_bearing_flip_crossdomain",
+    "sphinx-doc__sphinx-9461": "load_bearing_flip_crossdomain",
+    # Variance-floor stable PASS (5)
+    "django__django-10554": "variance_floor_pass",
+    "sympy__sympy-11618": "variance_floor_pass",
+    "matplotlib__matplotlib-14623": "variance_floor_pass",
+    "scikit-learn__scikit-learn-10297": "variance_floor_pass",
+    "sphinx-doc__sphinx-10466": "variance_floor_pass",
+    # Variance-floor stable FAIL (5)
+    "sympy__sympy-12489": "variance_floor_fail",
+    "matplotlib__matplotlib-22865": "variance_floor_fail",
+    "matplotlib__matplotlib-23314": "variance_floor_fail",
+    "sphinx-doc__sphinx-7590": "variance_floor_fail",
+    "sphinx-doc__sphinx-7748": "variance_floor_fail",
+}
+
+# v0.9 expected outcome per instance (from RESULTS.md). Used to compute
+# the "same direction as seed 1" replication metric.
+V09_EXPECTED: dict[str, dict[str, bool]] = {
+    # Load-bearing flips: baseline FAIL, treatment PASS
+    "django__django-11400": {"baseline": False, "treatment": True},
+    "django__django-13212": {"baseline": False, "treatment": True},
+    "django__django-13344": {"baseline": False, "treatment": True},
+    "sympy__sympy-16597": {"baseline": False, "treatment": True},
+    # Load-bearing regression: baseline PASS, treatment FAIL
+    "sympy__sympy-17630": {"baseline": True, "treatment": False},
+    # Cross-domain flips: baseline FAIL, treatment PASS
+    "scikit-learn__scikit-learn-14087": {"baseline": False, "treatment": True},
+    "sphinx-doc__sphinx-9461": {"baseline": False, "treatment": True},
+    # Variance-floor pass: both PASS
+    "django__django-10554": {"baseline": True, "treatment": True},
+    "sympy__sympy-11618": {"baseline": True, "treatment": True},
+    "matplotlib__matplotlib-14623": {"baseline": True, "treatment": True},
+    "scikit-learn__scikit-learn-10297": {"baseline": True, "treatment": True},
+    "sphinx-doc__sphinx-10466": {"baseline": True, "treatment": True},
+    # Variance-floor fail: both FAIL
+    "sympy__sympy-12489": {"baseline": False, "treatment": False},
+    "matplotlib__matplotlib-22865": {"baseline": False, "treatment": False},
+    "matplotlib__matplotlib-23314": {"baseline": False, "treatment": False},
+    "sphinx-doc__sphinx-7590": {"baseline": False, "treatment": False},
+    "sphinx-doc__sphinx-7748": {"baseline": False, "treatment": False},
+}
+
+
+def load_results(path: Path) -> dict[str, bool]:
+    """Load a results JSONL and return instance_id -> resolved (bool) map."""
+    if not path.exists():
+        return {}
+    out: dict[str, bool] = {}
+    with path.open() as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            r = json.loads(line)
+            out[r["instance_id"]] = bool(r.get("resolved", False))
+    return out
+
+
+def classify_stability(seed_outcomes: list[Optional[bool]]) -> str:
+    """Given a list of seed outcomes (True/False/None for missing), classify."""
+    present = [v for v in seed_outcomes if v is not None]
+    if not present:
+        return "no_data"
+    if len(present) == 1:
+        return "single_seed"
+    if all(v is True for v in present):
+        return "stable_pass"
+    if all(v is False for v in present):
+        return "stable_fail"
+    return "flaky"
+
+
+def bootstrap_ci(samples: list[float], n_iter: int = 10000, ci: float = 0.95) -> tuple[float, float]:
+    """Bootstrap confidence interval on the mean."""
+    if not samples:
+        return (0.0, 0.0)
+    rng = random.Random(20260625)
+    means: list[float] = []
+    n = len(samples)
+    for _ in range(n_iter):
+        resample = [samples[rng.randrange(n)] for _ in range(n)]
+        means.append(sum(resample) / n)
+    means.sort()
+    lo_idx = int((1 - ci) / 2 * n_iter)
+    hi_idx = int((1 + ci) / 2 * n_iter)
+    return (means[lo_idx], means[hi_idx])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seed1-baseline", type=Path, default=Path("baseline_results.jsonl"))
+    parser.add_argument("--seed1-baseline-s2", type=Path, default=Path("baseline_results_s2.jsonl"))
+    parser.add_argument("--seed1-treatment", type=Path, default=Path("treatment_results_s1.jsonl"))
+    parser.add_argument(
+        "--seed1-treatment-s2",
+        type=Path,
+        default=Path("treatment_results_s2_crossdomain.jsonl"),
+    )
+    parser.add_argument("--seed2-baseline", type=Path, default=Path("baseline_results_seed2.jsonl"))
+    parser.add_argument(
+        "--seed2-treatment", type=Path, default=Path("treatment_results_seed2_treatment.jsonl")
+    )
+    parser.add_argument("--seed3-baseline", type=Path, default=Path("baseline_results_seed3.jsonl"))
+    parser.add_argument(
+        "--seed3-treatment", type=Path, default=Path("treatment_results_seed3_treatment.jsonl")
+    )
+    parser.add_argument(
+        "--instance-ids",
+        nargs="*",
+        default=None,
+        help="Override the locked SMART_SUBSET list. Default: 17 instances from SEED_PLAN.md.",
+    )
+    parser.add_argument("--out", type=Path, default=Path("multi_seed_summary.json"))
+    args = parser.parse_args()
+
+    # Combine seed 1 baseline (Subset 1 + Subset 2) and treatment.
+    seed1_baseline = {**load_results(args.seed1_baseline), **load_results(args.seed1_baseline_s2)}
+    seed1_treatment = {
+        **load_results(args.seed1_treatment),
+        **load_results(args.seed1_treatment_s2),
+    }
+    seed2_baseline = load_results(args.seed2_baseline)
+    seed2_treatment = load_results(args.seed2_treatment)
+    seed3_baseline = load_results(args.seed3_baseline)
+    seed3_treatment = load_results(args.seed3_treatment)
+
+    target_ids = args.instance_ids or list(SMART_SUBSET.keys())
+
+    rows: list[dict] = []
+    for iid in target_ids:
+        category = SMART_SUBSET.get(iid, "custom")
+        baseline_seeds = [
+            seed1_baseline.get(iid),
+            seed2_baseline.get(iid),
+            seed3_baseline.get(iid),
+        ]
+        treatment_seeds = [
+            seed1_treatment.get(iid),
+            seed2_treatment.get(iid),
+            seed3_treatment.get(iid),
+        ]
+        b_present = [v for v in baseline_seeds if v is not None]
+        t_present = [v for v in treatment_seeds if v is not None]
+        b_pass_rate = sum(1 for v in b_present if v) / len(b_present) if b_present else None
+        t_pass_rate = sum(1 for v in t_present if v) / len(t_present) if t_present else None
+        b_stability = classify_stability(baseline_seeds)
+        t_stability = classify_stability(treatment_seeds)
+        # Paired delta across seeds where BOTH arms have data
+        delta = 0
+        n_paired = 0
+        for b, t in zip(baseline_seeds, treatment_seeds):
+            if b is not None and t is not None:
+                delta += (1 if t else 0) - (1 if b else 0)
+                n_paired += 1
+        # Same-direction-as-seed-1 check (for load-bearing instances)
+        expected = V09_EXPECTED.get(iid)
+        same_direction_seeds = []
+        if expected:
+            for b, t in zip(baseline_seeds, treatment_seeds):
+                if b is None or t is None:
+                    continue
+                # Same direction = both arms match the seed-1 outcome
+                if b == expected["baseline"] and t == expected["treatment"]:
+                    same_direction_seeds.append(True)
+                else:
+                    same_direction_seeds.append(False)
+        rows.append(
+            {
+                "instance_id": iid,
+                "category": category,
+                "baseline_seeds": baseline_seeds,
+                "treatment_seeds": treatment_seeds,
+                "baseline_pass_rate": b_pass_rate,
+                "treatment_pass_rate": t_pass_rate,
+                "baseline_stability": b_stability,
+                "treatment_stability": t_stability,
+                "paired_delta_sum": delta,
+                "n_paired_seeds": n_paired,
+                "same_direction_seeds": same_direction_seeds,
+                "v09_expected": expected,
+            }
+        )
+
+    # Per-instance paired delta (treatment_passes - baseline_passes across seeds)
+    deltas = [r["paired_delta_sum"] for r in rows if r["n_paired_seeds"] > 0]
+    mean_delta = sum(deltas) / len(deltas) if deltas else 0.0
+    ci_lo, ci_hi = bootstrap_ci(deltas) if deltas else (0.0, 0.0)
+
+    # Load-bearing replication count
+    load_bearing_rows = [
+        r for r in rows if r["category"].startswith("load_bearing")
+    ]
+    load_bearing_replicated = 0
+    for r in load_bearing_rows:
+        sd = r["same_direction_seeds"]
+        # Strict: ALL seeds match the v0.9 direction
+        if sd and all(sd):
+            load_bearing_replicated += 1
+
+    # Replication interpretation requires at least 2 seeds of data on
+    # the load-bearing rows. Until seed 2 lands, the "interpretation" is
+    # a trivial restatement of seed 1.
+    max_seeds_present = max(
+        (r["n_paired_seeds"] for r in load_bearing_rows), default=0
+    )
+    interpretation = "no_data"
+    if not load_bearing_rows:
+        interpretation = "no_data"
+    elif max_seeds_present < 2:
+        interpretation = "seed1_only_baseline"
+    elif load_bearing_replicated >= 5:
+        interpretation = "strong_replication"
+    elif load_bearing_replicated >= 3:
+        interpretation = "moderate_replication"
+    else:
+        interpretation = "weak_replication"
+
+    # Variance-floor summaries
+    floor_pass_rows = [r for r in rows if r["category"] == "variance_floor_pass"]
+    floor_fail_rows = [r for r in rows if r["category"] == "variance_floor_fail"]
+    floor_pass_counts: dict[str, int] = defaultdict(int)
+    floor_fail_counts: dict[str, int] = defaultdict(int)
+    for r in floor_pass_rows:
+        floor_pass_counts[r["baseline_stability"]] += 1
+        floor_pass_counts[r["treatment_stability"]] += 1
+    for r in floor_fail_rows:
+        floor_fail_counts[r["baseline_stability"]] += 1
+        floor_fail_counts[r["treatment_stability"]] += 1
+
+    summary = {
+        "rows": rows,
+        "load_bearing": {
+            "n_instances": len(load_bearing_rows),
+            "replicated_count": load_bearing_replicated,
+            "interpretation": interpretation,
+        },
+        "variance_floor": {
+            "pass_floor_counts": dict(floor_pass_counts),
+            "fail_floor_counts": dict(floor_fail_counts),
+        },
+        "paired_delta_summary": {
+            "n_instances": len(deltas),
+            "mean_delta": mean_delta,
+            "bootstrap_95_ci": [ci_lo, ci_hi],
+        },
+    }
+
+    args.out.write_text(json.dumps(summary, indent=2, default=str))
+
+    # Human-readable table to stdout
+    print(f"\n{'instance_id':<45} {'category':<32} {'b_seeds':<14} {'t_seeds':<14} {'delta':<6}")
+    print("-" * 115)
+    for r in rows:
+        b = "/".join("P" if v is True else "F" if v is False else "-" for v in r["baseline_seeds"])
+        t = "/".join("P" if v is True else "F" if v is False else "-" for v in r["treatment_seeds"])
+        print(
+            f"  {r['instance_id']:<43} {r['category']:<32} {b:<14} {t:<14} {r['paired_delta_sum']:+d}/{r['n_paired_seeds']}"
+        )
+
+    print()
+    print(f"Load-bearing replication: {load_bearing_replicated}/{len(load_bearing_rows)} → {interpretation}")
+    print(
+        f"Mean paired delta across {len(deltas)} instances: {mean_delta:+.2f} (95% CI [{ci_lo:+.2f}, {ci_hi:+.2f}])"
+    )
+    print()
+    print(f"Variance-floor PASS instances: {dict(floor_pass_counts)}")
+    print(f"Variance-floor FAIL instances: {dict(floor_fail_counts)}")
+    print()
+    print(f"Summary JSON written to: {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two prep artifacts for the v0.10 multi-seed replication of the v0.9 SWE-bench Verified benchmark. Locked BEFORE any seed-2 run executes, same discipline as v0.9 DESIGN.md.

## Files

- `benchmarks/repeat-mistake/SEED_PLAN.md` — pre-registered subset (17 instances), metrics, thresholds
- `benchmarks/repeat-mistake/multi_seed_aggregate.py` — variance analyzer, smoke-tested on seed-1 data

## Why now

v0.9 limitation #1 is single-trial design. Multi-seed replication is the highest-leverage next move per the v0.10 roadmap in README.md. Locking the methodology now (subset, metrics, thresholds) prevents goalpost-moving once seed-2 data lands.

## Subset rationale

Full 3-seed run on all 49 paired instances would cost ~60 hours and ~$180 USD. Smart subset (7 load-bearing flips/regression + 10 variance-floor samples) costs ~30 hours and ~$60 while preserving the load-bearing replication test.

## What this does NOT do

- Does not modify v0.9.1 shipped code
- Does not change RESULTS.md
- Does not execute any seed-2 run yet (the plan locks BEFORE the run)

## Test plan

- [x] Aggregator smoke-tested against existing v0.9 data
- [x] Output correctly labels "seed1_only_baseline" when only seed 1 data is present
- [x] No code change to shipped v0.9.1 artifacts