### PR TITLE
v0.10 kickoff: OpenClaw adapter (MCP registration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,23 @@ python -m world_model_server.cli install-codex
 
 `--dry-run` prints what would be appended without writing; `--force` re-appends even if the adapter marker is already present. The bundled snippet uses `world_model` (underscore) as the MCP server name to dodge Codex's silent hyphen-strip in its tool-name sanitizer. Hook output is camelCase with `deny_unknown_fields` compliance against Codex's strict Rust schema; the contract is locked down by tests in `tests/test_v075_features.py`. See [adapters/codex/README.md](adapters/codex/README.md).
 
+### Option 7: Run inside OpenClaw (experimental, v0.10)
+
+For users of [OpenClaw](https://github.com/openclaw/openclaw), the local-first personal AI assistant that routes across WhatsApp, Telegram, Slack, and Discord:
+
+```bash
+pip install world-model-mcp
+python -m world_model_server.cli setup
+openclaw mcp add world-model \
+    --command python3 \
+    --arg -m \
+    --arg world_model_server.server \
+    --env WORLD_MODEL_DB_PATH=.claude/world-model
+# Restart the OpenClaw gateway; verify with: openclaw mcp list
+```
+
+Pure additive integration — OpenClaw ships no native memory layer, so all 26 world-model tools become available to OpenClaw agent turns without capability overlap. This is MCP-registration only in v0.10; a TypeScript plugin bundle for typed lifecycle hooks (`before_prompt_build`, `before_tool_call`, `before_compaction`, `session_start`, ...) is on the v0.10.x roadmap. See [adapters/openclaw/README.md](adapters/openclaw/README.md).
+
 ### What Gets Installed
 
 ```
@@ -620,15 +637,19 @@ v0.7.3 added anonymous usage telemetry. It is:
 ### v0.9.2 (Shipped 2026-06-30) — Multi-seed replication appendix
 - [x] Pre-registered 17-instance multi-seed test per `benchmarks/repeat-mistake/SEED_PLAN.md` (locked 2026-06-25). Outcome: load-bearing replication 0 of 7; mean paired delta across two seeds is +0.24 per instance, bootstrap 95 percent CI [0.00, 0.47]. The v0.9 +10.2 pts headline was substantially attributable to an unlucky baseline draw. Honest update published per the pre-registered acceptance criteria. Appendix in `RESULTS.md` and `paper.md`. Zenodo record updated to version 2.
 
-### v0.10 (Next, in design)
+### v0.10 (In progress)
+- [x] **OpenClaw adapter (MCP registration)**. First v0.10 adapter shipped. Registers world-model-mcp as an MCP server inside OpenClaw via `openclaw mcp add` — pure additive since OpenClaw ships no native memory layer. See [`adapters/openclaw/`](./adapters/openclaw/). Follow-ups tracked: `install-openclaw` CLI subcommand, TypeScript plugin bundle for typed lifecycle hooks (`before_prompt_build`, `before_tool_call`, `before_compaction`, `session_start`, ...).
+- [ ] Hermes Agent adapter (MCP route). Hermes v0.17.0 (NousResearch, MIT) has first-class MCP client support plus a documented `MemoryProvider` plugin ABC. Ship the MCP route first; native plugin only if MCP route shows traction — Hermes allows exactly one external memory provider active at a time and [yoloshii/ClawMem](https://github.com/yoloshii/ClawMem) already occupies that slot for many users.
+- [ ] Continue adapter. Largest OSS coding agent not tied to a platform vendor; higher priority after the SpaceX/Cursor acquisition changes the platform-risk math.
 - [ ] Full-corpus multi-seed replication: all 49 paired instances at 3-5 seeds (the v0.9.2 update covers a 17-instance subset only). The 17-instance subset surfaced the variance signal; the full-corpus run quantifies it across the entire benchmark.
 - [ ] Larger task counts per repo; broader corpus coverage beyond the 50-task subset.
-- [ ] Head-to-head benchmarks against other memory layers (mem0, Letta, Zep, piia-engram).
+- [ ] Head-to-head benchmarks against other memory layers (mem0, Letta, Zep, piia-engram, ClawMem).
 - [ ] Explicit failure-mode-similarity scoring to predict when cross-domain transfer will succeed.
 - [ ] `auto` strategy rewrite to fold in `confirmer` + decay awareness (should lift the v0.8.1 contradiction-resolution benchmark's auto score from 77.1% past 90%).
 - [ ] Antigravity CLI adapter (held pending a `TransformCompactionHook` in the SDK for the load-bearing memory-injection contract).
 - [ ] MCP spec readiness for upcoming spec versions (stateless transport, `_meta` headers, `InputRequiredResult`).
 - [ ] Cline adapter (lower urgency after they shipped global AGENTS rules in v3.86).
+- [ ] Windsurf adapter.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -211,17 +211,13 @@ For users of [OpenClaw](https://github.com/openclaw/openclaw), the local-first p
 ```bash
 pip install world-model-mcp
 python -m world_model_server.cli setup
-# NOTE: --command MUST be the absolute path to python3.
-# OpenClaw's process spawn does not inherit your shell PATH.
-openclaw mcp add world-model \
-    --command "$(which python3)" \
-    --arg -m \
-    --arg world_model_server.server \
-    --env WORLD_MODEL_DB_PATH=.claude/world-model
+python -m world_model_server.cli install-openclaw
 # Verify: openclaw mcp probe world-model  (should report 27 tools)
 ```
 
-Pure additive integration — OpenClaw ships no native memory layer, so all 27 world-model tools become available to OpenClaw agent turns without capability overlap. Verified end-to-end against OpenClaw `2026.6.11 (e085fa1)` on macOS on 2026-07-01. This is MCP-registration only in v0.10; a TypeScript plugin bundle for typed lifecycle hooks (`before_prompt_build`, `before_tool_call`, `before_compaction`, `session_start`, ...) is on the v0.10.x roadmap. See [adapters/openclaw/README.md](adapters/openclaw/README.md).
+`install-openclaw` merges an `mcp.servers.world-model` entry into `~/.openclaw/openclaw.json` while preserving all other keys in the config file. It defaults the `command` field to `sys.executable` (absolute path to the interpreter running the CLI) — necessary because OpenClaw's process spawn does not inherit shell PATH; a bare `python3` fails probe with `MCP error -32000: Connection closed`. Flags: `--force` (overwrite existing entry), `--dry-run` (print without writing), `--python <abs-path>` (override interpreter), `--db-path <path>` (override `WORLD_MODEL_DB_PATH`, default `.claude/world-model`). Relative `--python` values are rejected as a hard error.
+
+Pure additive integration — OpenClaw ships no native memory layer, so all 27 world-model tools become available to OpenClaw agent turns without capability overlap. Verified end-to-end against OpenClaw `2026.6.11 (e085fa1)` on macOS on 2026-07-01. MCP-registration only in v0.10; a TypeScript plugin bundle for typed lifecycle hooks (`before_prompt_build`, `before_tool_call`, `before_compaction`, `session_start`, ...) is on the v0.10.x roadmap. See [adapters/openclaw/README.md](adapters/openclaw/README.md).
 
 ### What Gets Installed
 
@@ -640,7 +636,7 @@ v0.7.3 added anonymous usage telemetry. It is:
 - [x] Pre-registered 17-instance multi-seed test per `benchmarks/repeat-mistake/SEED_PLAN.md` (locked 2026-06-25). Outcome: load-bearing replication 0 of 7; mean paired delta across two seeds is +0.24 per instance, bootstrap 95 percent CI [0.00, 0.47]. The v0.9 +10.2 pts headline was substantially attributable to an unlucky baseline draw. Honest update published per the pre-registered acceptance criteria. Appendix in `RESULTS.md` and `paper.md`. Zenodo record updated to version 2.
 
 ### v0.10 (In progress)
-- [x] **OpenClaw adapter (MCP registration)**. First v0.10 adapter shipped. Registers world-model-mcp as an MCP server inside OpenClaw via `openclaw mcp add` — pure additive since OpenClaw ships no native memory layer. Verified end-to-end against OpenClaw `2026.6.11 (e085fa1)` on macOS on 2026-07-01: `openclaw mcp probe world-model` reports 27 tools discovered. See [`adapters/openclaw/`](./adapters/openclaw/). Follow-ups tracked: `install-openclaw` CLI subcommand, TypeScript plugin bundle for typed lifecycle hooks (`before_prompt_build`, `before_tool_call`, `before_compaction`, `session_start`, ...).
+- [x] **OpenClaw adapter (MCP registration) + `install-openclaw` CLI**. First v0.10 adapter shipped. Registers world-model-mcp as an MCP server inside OpenClaw via `python -m world_model_server.cli install-openclaw` (or manual `openclaw mcp add`) — pure additive since OpenClaw ships no native memory layer. The CLI merges into `~/.openclaw/openclaw.json` preserving other keys, defaults the interpreter path to `sys.executable` (absolute), rejects relative `--python` overrides (OpenClaw's process spawn does not inherit shell PATH), and supports `--dry-run` / `--force` / `--db-path`. Verified end-to-end against OpenClaw `2026.6.11 (e085fa1)` on macOS on 2026-07-01: `openclaw mcp probe world-model` reports 27 tools discovered. See [`adapters/openclaw/`](./adapters/openclaw/). Remaining follow-up: TypeScript plugin bundle for typed lifecycle hooks (`before_prompt_build`, `before_tool_call`, `before_compaction`, `session_start`, ...) — will ship only if MCP-only adoption justifies the plugin work.
 - [ ] Hermes Agent adapter (MCP route). Hermes v0.17.0 (NousResearch, MIT) has first-class MCP client support plus a documented `MemoryProvider` plugin ABC. Ship the MCP route first; native plugin only if MCP route shows traction — Hermes allows exactly one external memory provider active at a time and [yoloshii/ClawMem](https://github.com/yoloshii/ClawMem) already occupies that slot for many users.
 - [ ] Continue adapter. Largest OSS coding agent not tied to a platform vendor; higher priority after the SpaceX/Cursor acquisition changes the platform-risk math.
 - [ ] Full-corpus multi-seed replication: all 49 paired instances at 3-5 seeds (the v0.9.2 update covers a 17-instance subset only). The 17-instance subset surfaced the variance signal; the full-corpus run quantifies it across the entire benchmark.

--- a/README.md
+++ b/README.md
@@ -211,15 +211,17 @@ For users of [OpenClaw](https://github.com/openclaw/openclaw), the local-first p
 ```bash
 pip install world-model-mcp
 python -m world_model_server.cli setup
+# NOTE: --command MUST be the absolute path to python3.
+# OpenClaw's process spawn does not inherit your shell PATH.
 openclaw mcp add world-model \
-    --command python3 \
+    --command "$(which python3)" \
     --arg -m \
     --arg world_model_server.server \
     --env WORLD_MODEL_DB_PATH=.claude/world-model
-# Restart the OpenClaw gateway; verify with: openclaw mcp list
+# Verify: openclaw mcp probe world-model  (should report 27 tools)
 ```
 
-Pure additive integration — OpenClaw ships no native memory layer, so all 26 world-model tools become available to OpenClaw agent turns without capability overlap. This is MCP-registration only in v0.10; a TypeScript plugin bundle for typed lifecycle hooks (`before_prompt_build`, `before_tool_call`, `before_compaction`, `session_start`, ...) is on the v0.10.x roadmap. See [adapters/openclaw/README.md](adapters/openclaw/README.md).
+Pure additive integration — OpenClaw ships no native memory layer, so all 27 world-model tools become available to OpenClaw agent turns without capability overlap. Verified end-to-end against OpenClaw `2026.6.11 (e085fa1)` on macOS on 2026-07-01. This is MCP-registration only in v0.10; a TypeScript plugin bundle for typed lifecycle hooks (`before_prompt_build`, `before_tool_call`, `before_compaction`, `session_start`, ...) is on the v0.10.x roadmap. See [adapters/openclaw/README.md](adapters/openclaw/README.md).
 
 ### What Gets Installed
 
@@ -638,7 +640,7 @@ v0.7.3 added anonymous usage telemetry. It is:
 - [x] Pre-registered 17-instance multi-seed test per `benchmarks/repeat-mistake/SEED_PLAN.md` (locked 2026-06-25). Outcome: load-bearing replication 0 of 7; mean paired delta across two seeds is +0.24 per instance, bootstrap 95 percent CI [0.00, 0.47]. The v0.9 +10.2 pts headline was substantially attributable to an unlucky baseline draw. Honest update published per the pre-registered acceptance criteria. Appendix in `RESULTS.md` and `paper.md`. Zenodo record updated to version 2.
 
 ### v0.10 (In progress)
-- [x] **OpenClaw adapter (MCP registration)**. First v0.10 adapter shipped. Registers world-model-mcp as an MCP server inside OpenClaw via `openclaw mcp add` — pure additive since OpenClaw ships no native memory layer. See [`adapters/openclaw/`](./adapters/openclaw/). Follow-ups tracked: `install-openclaw` CLI subcommand, TypeScript plugin bundle for typed lifecycle hooks (`before_prompt_build`, `before_tool_call`, `before_compaction`, `session_start`, ...).
+- [x] **OpenClaw adapter (MCP registration)**. First v0.10 adapter shipped. Registers world-model-mcp as an MCP server inside OpenClaw via `openclaw mcp add` — pure additive since OpenClaw ships no native memory layer. Verified end-to-end against OpenClaw `2026.6.11 (e085fa1)` on macOS on 2026-07-01: `openclaw mcp probe world-model` reports 27 tools discovered. See [`adapters/openclaw/`](./adapters/openclaw/). Follow-ups tracked: `install-openclaw` CLI subcommand, TypeScript plugin bundle for typed lifecycle hooks (`before_prompt_build`, `before_tool_call`, `before_compaction`, `session_start`, ...).
 - [ ] Hermes Agent adapter (MCP route). Hermes v0.17.0 (NousResearch, MIT) has first-class MCP client support plus a documented `MemoryProvider` plugin ABC. Ship the MCP route first; native plugin only if MCP route shows traction — Hermes allows exactly one external memory provider active at a time and [yoloshii/ClawMem](https://github.com/yoloshii/ClawMem) already occupies that slot for many users.
 - [ ] Continue adapter. Largest OSS coding agent not tied to a platform vendor; higher priority after the SpaceX/Cursor acquisition changes the platform-risk math.
 - [ ] Full-corpus multi-seed replication: all 49 paired instances at 3-5 seeds (the v0.9.2 update covers a 17-instance subset only). The 17-instance subset surfaced the variance signal; the full-corpus run quantifies it across the entire benchmark.

--- a/adapters/openclaw/README.md
+++ b/adapters/openclaw/README.md
@@ -1,0 +1,193 @@
+# OpenClaw adapter (experimental)
+
+This adapter wires `world-model-mcp` into [OpenClaw](https://github.com/openclaw/openclaw)
+as an external MCP server. OpenClaw is a local-first personal AI assistant
+that routes conversations across WhatsApp, Telegram, Slack, Discord and
+other channels. It ships no native memory layer, so world-model-mcp is
+pure additive here: persistent facts, per-fact provenance, and per-evidence
+decay for a runtime that had none of those.
+
+Status: experimental. Verified against the OpenClaw config schema
+documented at [docs.openclaw.ai/cli/mcp](https://docs.openclaw.ai/cli/mcp)
+as of 2026-07-01. PRs welcome for any breakage; see the
+**Reporting issues** section.
+
+## What you get
+
+- `world-model-mcp` registered as an MCP server inside OpenClaw, exposing
+  the same 26 tools that the Claude Code, Cursor, Codex, and pi adapters
+  expose (`query_fact`, `validate_change`, `find_contradictions`,
+  `resolve_contradiction`, `get_injection_context`, `get_compaction_audit`,
+  and so on).
+- No overlap with any built-in OpenClaw memory layer — because OpenClaw
+  does not ship one. All persistence is world-model-mcp's schema.
+
+This first cut is **MCP-only**. OpenClaw exposes an extensive typed
+lifecycle hook surface (`before_prompt_build`, `before_tool_call`,
+`session_start`, `before_compaction`, ...). Wiring those into
+world-model-mcp requires an OpenClaw plugin bundle (TypeScript) and is
+tracked separately — see **Roadmap for this adapter** below.
+
+## Install (from your project root)
+
+```bash
+# 1. Install the package
+pip install -U world-model-mcp
+
+# 2. Initialize the world-model database in this project
+python -m world_model_server.cli setup
+
+# 3. Register world-model as an MCP server in OpenClaw
+openclaw mcp add world-model \
+    --command python3 \
+    --arg -m \
+    --arg world_model_server.server \
+    --env WORLD_MODEL_DB_PATH=.claude/world-model
+```
+
+Step 3 writes into `~/.openclaw/openclaw.json` under the `mcp.servers`
+object. The equivalent JSON snippet, if you prefer to edit the config
+file by hand, is bundled as [`openclaw.json`](./openclaw.json):
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "world-model": {
+        "command": "python3",
+        "args": ["-m", "world_model_server.server"],
+        "env": {
+          "WORLD_MODEL_DB_PATH": ".claude/world-model"
+        }
+      }
+    }
+  }
+}
+```
+
+Then restart the OpenClaw gateway. Verify the wire-up with:
+
+```bash
+openclaw mcp list
+```
+
+`world-model` should appear in the list. From an OpenClaw agent session,
+any tool with the `world-model` prefix confirms the server is reachable.
+
+## Where the database lives
+
+The adapter uses `.claude/world-model/` as the database path, matching
+the Claude Code and Cursor adapters. If you run world-model-mcp with both
+OpenClaw and one of those clients against the same project, they share
+the same store.
+
+If you want OpenClaw's world-model DB in a different location (for
+example, OpenClaw is a user-wide install and you want a user-wide
+world-model DB), override with an absolute path:
+
+```bash
+openclaw mcp add world-model \
+    --command python3 \
+    --arg -m \
+    --arg world_model_server.server \
+    --env WORLD_MODEL_DB_PATH=/absolute/path/to/world-model
+```
+
+## What OpenClaw sees
+
+OpenClaw's LLM turn will see `world-model` in its available tool list,
+same as any other MCP server registered via `openclaw mcp add`. The
+LLM can then call `query_fact` to check what has been learned about
+the user, `validate_change` before writing to files (if OpenClaw is
+running a coding-adjacent workflow), or `get_injection_context` to pull
+the top constraints and recent facts into its own prompt.
+
+For channel workflows (WhatsApp/Telegram/Slack) the most useful tools
+are typically:
+
+| Tool | Why it helps |
+| --- | --- |
+| `query_fact` | Look up what has been established about the user, a project, or a channel |
+| `assert_fact` | Record a new fact from the conversation |
+| `find_contradictions` | Catch when a new user statement conflicts with a stored fact |
+| `resolve_contradiction` | Mark the winner (usually the newer statement) and archive the loser |
+| `get_injection_context` | Pull the top-N facts to inject into the next LLM turn |
+
+## Roadmap for this adapter
+
+The MCP-only integration ships in v0.10. Two follow-ups are on the roadmap:
+
+**v0.10.x — `install-openclaw` CLI subcommand.** Parity with
+`install-cursor` and `install-codex`: a single command that runs
+`openclaw mcp add` for you with sensible defaults and prints what
+changed. Until this ships, the manual `openclaw mcp add` command in
+Step 3 above is the supported path.
+
+**v0.10.x or later — OpenClaw plugin bundle for typed lifecycle hooks.**
+OpenClaw exposes a rich set of hook events documented at
+[docs.openclaw.ai/plugins/hooks](https://docs.openclaw.ai/plugins/hooks):
+`before_prompt_build`, `before_tool_call`, `after_tool_call`,
+`session_start`, `session_end`, `before_compaction`, `after_compaction`,
+and more. Wiring these into world-model-mcp gives OpenClaw the same
+PreToolUse-defer, PostCompact-inject, and SessionStart-warm behavior
+the Claude Code and Cursor adapters ship. This requires a TypeScript
+plugin bundle. It will land only if MCP-only adoption of the OpenClaw
+adapter justifies the plugin work.
+
+## Overlap with ClawMem
+
+[yoloshii/ClawMem](https://github.com/yoloshii/ClawMem) ships a
+cross-runtime memory adapter for Claude Code + OpenClaw + Hermes
+against a shared SQLite vault. If you already run ClawMem and are
+weighing whether to switch:
+
+- **ClawMem** is a plain SQLite vault: `key -> value` with timestamps.
+  Simple, cross-runtime, zero opinionated schema.
+- **world-model-mcp** is a schema-first store: per-fact provenance
+  (`asserted_by`, `confirmer`, `confirmation_state`, `evidence_type`,
+  `last_decay_at`), per-evidence-type decay half-lives (test 180d,
+  bug_fix 365d, user_correction 730d, source_code 365d, session 14d),
+  a `PreToolUse` defer enforcement tier for hooks, and a pre-registered
+  SWE-bench Verified benchmark with published methodology (see
+  [`benchmarks/repeat-mistake/`](../../benchmarks/repeat-mistake/) and
+  Zenodo DOI 10.5281/zenodo.20834509).
+
+The two are not drop-in replacements. Pick ClawMem if you want a lightweight
+shared vault. Pick world-model-mcp if you want the schema and enforcement
+depth described above.
+
+## Caveats
+
+- **MCP-only, no hooks yet.** The current adapter only wires the MCP
+  server. Lifecycle hook integration (defer, PostCompact-inject,
+  SessionStart-warm) requires a TypeScript plugin bundle — not shipped
+  in this cut.
+- **Interpreter env vars are blocked.** OpenClaw blocks
+  interpreter-startup environment variables like `PYTHONPATH` and
+  `NODE_OPTIONS` in the `env` block for security. If your Python setup
+  requires `PYTHONPATH` to find `world_model_server`, install it into
+  the environment `python3` resolves to instead of relying on the env
+  block.
+- **`python3` on PATH.** The adapter uses `python3` as the command. On
+  systems where the world-model-mcp interpreter is a venv or `pyenv`
+  install, you may need to replace `python3` with the absolute path to
+  the correct interpreter. Get the path with `which python3` from a
+  shell where `python -c "import world_model_server"` works.
+- **Working directory.** Because `WORLD_MODEL_DB_PATH=.claude/world-model`
+  is a relative path, it resolves against OpenClaw's process working
+  directory. If OpenClaw is a user-wide gateway (not launched from a
+  project root), use an absolute `WORLD_MODEL_DB_PATH` instead.
+- **HTTP transport.** If you deploy world-model-mcp over HTTP (Modal or
+  similar; see [docs/deployment/managed-agents-self-hosted.md](../../docs/deployment/managed-agents-self-hosted.md)),
+  register the server with `transport: "streamable-http"` and a `url:`
+  field instead of `command`/`args`.
+
+## Reporting issues
+
+Open an issue on the main repo with the `adapter:openclaw` label:
+<https://github.com/SaravananJaichandar/world-model-mcp/issues>
+
+Include:
+- OpenClaw version (`openclaw --version`)
+- Relevant `~/.openclaw/openclaw.json` `mcp.servers` block
+- Any gateway stderr for the world-model process

--- a/adapters/openclaw/README.md
+++ b/adapters/openclaw/README.md
@@ -28,7 +28,7 @@ lifecycle hook surface (`before_prompt_build`, `before_tool_call`,
 world-model-mcp requires an OpenClaw plugin bundle (TypeScript) and is
 tracked separately — see **Roadmap for this adapter** below.
 
-## Install (from your project root)
+## Install (recommended: CLI subcommand)
 
 ```bash
 # 1. Install the package
@@ -38,9 +38,37 @@ pip install -U world-model-mcp
 python -m world_model_server.cli setup
 
 # 3. Register world-model as an MCP server in OpenClaw
-#    Use the ABSOLUTE path to python3 — OpenClaw's process spawn does
-#    not inherit your shell's PATH, so `python3` alone will fail with
-#    "MCP error -32000: Connection closed" during probe.
+python -m world_model_server.cli install-openclaw
+```
+
+Step 3 merges an entry into `~/.openclaw/openclaw.json` under
+`mcp.servers.world-model`, preserving all other keys in the file.
+Defaults the `command` field to `sys.executable` (the absolute path
+to the interpreter running the CLI), which side-steps the OpenClaw
+PATH-spawn issue described in **Caveats** below.
+
+**Flags** — `install-openclaw` supports:
+
+| Flag | Purpose |
+| --- | --- |
+| `--config-path PATH` | Override `~/.openclaw/openclaw.json` (used by tests; not usually needed) |
+| `--python PATH` | Absolute path to the python3 you want OpenClaw to spawn. Default: the interpreter running the CLI. Relative values are rejected. |
+| `--db-path PATH` | Value for `WORLD_MODEL_DB_PATH`. Default: `.claude/world-model` |
+| `--dry-run` | Print the proposed `mcp.servers.world-model` entry without writing |
+| `--force` | Replace the entry if `mcp.servers.world-model` already exists |
+
+Verify the wire-up:
+
+```bash
+openclaw mcp probe world-model
+# Expect: - world-model: 27 tools
+```
+
+## Manual install (fallback)
+
+If you want to skip the CLI and use OpenClaw's own tooling:
+
+```bash
 openclaw mcp add world-model \
     --command "$(which python3)" \
     --arg -m \
@@ -48,8 +76,8 @@ openclaw mcp add world-model \
     --env WORLD_MODEL_DB_PATH=.claude/world-model
 ```
 
-Step 3 writes into `~/.openclaw/openclaw.json` under the `mcp.servers`
-object. The equivalent JSON snippet, if you prefer to edit the config
+Same end result as `install-openclaw`. The absolute path for
+`--command` is critical — see **Caveats**. The equivalent JSON snippet, if you prefer to edit the config
 file by hand, is bundled as [`openclaw.json`](./openclaw.json). Replace
 `/absolute/path/to/python3` with the output of `which python3`:
 

--- a/adapters/openclaw/README.md
+++ b/adapters/openclaw/README.md
@@ -7,10 +7,10 @@ other channels. It ships no native memory layer, so world-model-mcp is
 pure additive here: persistent facts, per-fact provenance, and per-evidence
 decay for a runtime that had none of those.
 
-Status: experimental. Verified against the OpenClaw config schema
-documented at [docs.openclaw.ai/cli/mcp](https://docs.openclaw.ai/cli/mcp)
-as of 2026-07-01. PRs welcome for any breakage; see the
-**Reporting issues** section.
+Status: experimental. Verified end-to-end against OpenClaw
+`2026.6.11 (e085fa1)` on macOS on 2026-07-01: `openclaw mcp probe
+world-model` reports 27 tools discovered. PRs welcome for any breakage;
+see the **Reporting issues** section.
 
 ## What you get
 
@@ -38,8 +38,11 @@ pip install -U world-model-mcp
 python -m world_model_server.cli setup
 
 # 3. Register world-model as an MCP server in OpenClaw
+#    Use the ABSOLUTE path to python3 — OpenClaw's process spawn does
+#    not inherit your shell's PATH, so `python3` alone will fail with
+#    "MCP error -32000: Connection closed" during probe.
 openclaw mcp add world-model \
-    --command python3 \
+    --command "$(which python3)" \
     --arg -m \
     --arg world_model_server.server \
     --env WORLD_MODEL_DB_PATH=.claude/world-model
@@ -47,14 +50,15 @@ openclaw mcp add world-model \
 
 Step 3 writes into `~/.openclaw/openclaw.json` under the `mcp.servers`
 object. The equivalent JSON snippet, if you prefer to edit the config
-file by hand, is bundled as [`openclaw.json`](./openclaw.json):
+file by hand, is bundled as [`openclaw.json`](./openclaw.json). Replace
+`/absolute/path/to/python3` with the output of `which python3`:
 
 ```json
 {
   "mcp": {
     "servers": {
       "world-model": {
-        "command": "python3",
+        "command": "/absolute/path/to/python3",
         "args": ["-m", "world_model_server.server"],
         "env": {
           "WORLD_MODEL_DB_PATH": ".claude/world-model"
@@ -168,11 +172,14 @@ depth described above.
   requires `PYTHONPATH` to find `world_model_server`, install it into
   the environment `python3` resolves to instead of relying on the env
   block.
-- **`python3` on PATH.** The adapter uses `python3` as the command. On
-  systems where the world-model-mcp interpreter is a venv or `pyenv`
-  install, you may need to replace `python3` with the absolute path to
-  the correct interpreter. Get the path with `which python3` from a
-  shell where `python -c "import world_model_server"` works.
+- **`python3` MUST be an absolute path — bare `python3` will fail.**
+  OpenClaw's process spawn does not inherit your shell's PATH. If you
+  register the server with `--command python3` you will see
+  `MCP error -32000: Connection closed` on probe even though running
+  `python3 -m world_model_server.server` works fine from your shell.
+  Fix: use `$(which python3)` in the CLI command, or hand-edit
+  `~/.openclaw/openclaw.json` to substitute the absolute path.
+  Verified against OpenClaw `2026.6.11 (e085fa1)` on macOS on 2026-07-01.
 - **Working directory.** Because `WORLD_MODEL_DB_PATH=.claude/world-model`
   is a relative path, it resolves against OpenClaw's process working
   directory. If OpenClaw is a user-wide gateway (not launched from a

--- a/adapters/openclaw/openclaw.json
+++ b/adapters/openclaw/openclaw.json
@@ -1,0 +1,13 @@
+{
+  "mcp": {
+    "servers": {
+      "world-model": {
+        "command": "python3",
+        "args": ["-m", "world_model_server.server"],
+        "env": {
+          "WORLD_MODEL_DB_PATH": ".claude/world-model"
+        }
+      }
+    }
+  }
+}

--- a/adapters/openclaw/openclaw.json
+++ b/adapters/openclaw/openclaw.json
@@ -2,7 +2,7 @@
   "mcp": {
     "servers": {
       "world-model": {
-        "command": "python3",
+        "command": "/absolute/path/to/python3",
         "args": ["-m", "world_model_server.server"],
         "env": {
           "WORLD_MODEL_DB_PATH": ".claude/world-model"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ packages = ["world_model_server"]
 "world_model_server/adapters/pi/package.json" = "world_model_server/adapters/pi/package.json"
 "world_model_server/adapters/codex/config.toml" = "world_model_server/adapters/codex/config.toml"
 "world_model_server/adapters/codex/hooks_snippet.toml" = "world_model_server/adapters/codex/hooks_snippet.toml"
+"world_model_server/adapters/openclaw/openclaw.json" = "world_model_server/adapters/openclaw/openclaw.json"
 "world_model_server/hooks/world-model-capture.js" = "world_model_server/hooks/world-model-capture.js"
 "world_model_server/hooks/world-model-inject.js" = "world_model_server/hooks/world-model-inject.js"
 "world_model_server/hooks/world-model-session.js" = "world_model_server/hooks/world-model-session.js"

--- a/tests/test_v010_openclaw_features.py
+++ b/tests/test_v010_openclaw_features.py
@@ -1,0 +1,255 @@
+"""
+v0.10 OpenClaw adapter tests.
+
+F1: OpenClaw adapter bundled files (openclaw.json snippet)
+F2: install-openclaw CLI (dry-run, writes, idempotent, JSON merge preservation,
+    absolute-path enforcement, --python override, --db-path override)
+
+The install command merges into a JSON config at ~/.openclaw/openclaw.json
+rather than appending to TOML like install-codex does. That difference is
+what these tests exercise: the merge must preserve all other keys in the
+config file, must default the interpreter path to an absolute value
+(sys.executable), and must refuse to write a relative --python override.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+# ============================================================================
+# F1: Bundled adapter files
+# ============================================================================
+
+def test_f1_openclaw_adapter_dir_bundled():
+    """OpenClaw adapter files must be inside the package so installs from PyPI
+    ship them."""
+    bundle = REPO_ROOT / "world_model_server" / "adapters" / "openclaw"
+    assert bundle.exists()
+    assert (bundle / "openclaw.json").exists()
+
+
+def test_f1_openclaw_bundled_json_is_valid():
+    """The bundled openclaw.json snippet must be parseable JSON with
+    mcp.servers.world-model present."""
+    bundle = REPO_ROOT / "world_model_server" / "adapters" / "openclaw" / "openclaw.json"
+    data = json.loads(bundle.read_text())
+    assert "mcp" in data
+    assert "servers" in data["mcp"]
+    assert "world-model" in data["mcp"]["servers"]
+    entry = data["mcp"]["servers"]["world-model"]
+    assert entry["args"] == ["-m", "world_model_server.server"]
+    assert "WORLD_MODEL_DB_PATH" in entry["env"]
+
+
+def test_f1_openclaw_top_level_readme_exists():
+    """The top-level adapters/openclaw/README.md is what users browsing the
+    repo see first — it must exist."""
+    readme = REPO_ROOT / "adapters" / "openclaw" / "README.md"
+    assert readme.exists()
+    text = readme.read_text()
+    assert "OpenClaw" in text
+    assert "openclaw mcp add" in text
+
+
+# ============================================================================
+# F2: install-openclaw CLI
+# ============================================================================
+
+def test_f2_install_openclaw_dry_run(tmp_path):
+    """--dry-run prints proposed entry without writing."""
+    cfg = tmp_path / "openclaw.json"
+    original = {"messages": {"ackReactionScope": "group-mentions"}}
+    cfg.write_text(json.dumps(original))
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-openclaw",
+         "--config-path", str(cfg), "--dry-run"],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Would write" in result.stdout
+    # Config unchanged
+    assert json.loads(cfg.read_text()) == original
+
+
+def test_f2_install_openclaw_writes_and_defaults_absolute_python(tmp_path):
+    """First install merges the world-model entry with an absolute-path
+    default for --python (sys.executable)."""
+    cfg = tmp_path / "openclaw.json"
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-openclaw",
+         "--config-path", str(cfg)],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+
+    data = json.loads(cfg.read_text())
+    assert data["mcp"]["servers"]["world-model"]["args"] == ["-m", "world_model_server.server"]
+    # Default command MUST be an absolute path (sys.executable). OpenClaw
+    # spawn does not inherit shell PATH; a relative binary name breaks probe.
+    assert Path(data["mcp"]["servers"]["world-model"]["command"]).is_absolute()
+    assert data["mcp"]["servers"]["world-model"]["env"]["WORLD_MODEL_DB_PATH"] == ".claude/world-model"
+
+
+def test_f2_install_openclaw_preserves_other_config_keys(tmp_path):
+    """Merge must preserve every unrelated key in the existing openclaw.json."""
+    cfg = tmp_path / "openclaw.json"
+    original = {
+        "commands": {"native": "auto", "restart": True},
+        "messages": {"ackReactionScope": "group-mentions"},
+        "mcp": {"servers": {"pre-existing-server": {"command": "/bin/echo", "args": []}}},
+        "meta": {"lastTouchedVersion": "2026.6.11"},
+    }
+    cfg.write_text(json.dumps(original))
+
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-openclaw",
+         "--config-path", str(cfg)],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+
+    data = json.loads(cfg.read_text())
+    # Original top-level keys preserved
+    assert data["commands"] == original["commands"]
+    assert data["messages"] == original["messages"]
+    assert data["meta"] == original["meta"]
+    # Pre-existing MCP server preserved
+    assert "pre-existing-server" in data["mcp"]["servers"]
+    assert data["mcp"]["servers"]["pre-existing-server"] == original["mcp"]["servers"]["pre-existing-server"]
+    # New world-model entry added
+    assert "world-model" in data["mcp"]["servers"]
+
+
+def test_f2_install_openclaw_idempotent(tmp_path):
+    """Second install without --force refuses to overwrite."""
+    cfg = tmp_path / "openclaw.json"
+
+    subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-openclaw",
+         "--config-path", str(cfg)],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    first_text = cfg.read_text()
+
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-openclaw",
+         "--config-path", str(cfg)],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0
+    assert "already present" in result.stdout.lower()
+    # File unchanged
+    assert cfg.read_text() == first_text
+
+
+def test_f2_install_openclaw_force_overwrites(tmp_path):
+    """--force replaces the existing world-model entry."""
+    cfg = tmp_path / "openclaw.json"
+
+    # First install with default db-path
+    subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-openclaw",
+         "--config-path", str(cfg)],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    first = json.loads(cfg.read_text())
+    assert first["mcp"]["servers"]["world-model"]["env"]["WORLD_MODEL_DB_PATH"] == ".claude/world-model"
+
+    # Force overwrite with a different db-path
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-openclaw",
+         "--config-path", str(cfg), "--force", "--db-path", "/custom/db/path"],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+
+    second = json.loads(cfg.read_text())
+    assert second["mcp"]["servers"]["world-model"]["env"]["WORLD_MODEL_DB_PATH"] == "/custom/db/path"
+
+
+def test_f2_install_openclaw_rejects_relative_python(tmp_path):
+    """--python MUST be an absolute path. A relative value is a hard error
+    because OpenClaw's process spawn does not inherit shell PATH."""
+    cfg = tmp_path / "openclaw.json"
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-openclaw",
+         "--config-path", str(cfg), "--python", "python3"],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode != 0
+    assert "absolute path" in (result.stdout + result.stderr).lower()
+    # No config written
+    assert not cfg.exists()
+
+
+def test_f2_install_openclaw_creates_parent_dir(tmp_path):
+    """If ~/.openclaw/ doesn't exist, install creates it."""
+    cfg = tmp_path / "subdir" / "openclaw.json"
+    assert not cfg.parent.exists()
+
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-openclaw",
+         "--config-path", str(cfg)],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+    assert cfg.exists()
+
+
+def test_f2_install_openclaw_rejects_non_object_json(tmp_path):
+    """If the config file exists but is not a JSON object, refuse to write."""
+    cfg = tmp_path / "openclaw.json"
+    cfg.write_text('["a", "list", "not", "an", "object"]')
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-openclaw",
+         "--config-path", str(cfg)],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode != 0
+    # Config unchanged
+    assert cfg.read_text() == '["a", "list", "not", "an", "object"]'
+
+
+def test_f2_install_openclaw_rejects_malformed_json(tmp_path):
+    """Malformed JSON in the config file is a hard error, not a silent
+    overwrite."""
+    cfg = tmp_path / "openclaw.json"
+    cfg.write_text('{"mcp": {broken}')
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-openclaw",
+         "--config-path", str(cfg)],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode != 0
+    # Config unchanged
+    assert cfg.read_text() == '{"mcp": {broken}'
+
+
+# ============================================================================
+# F3: CLI subcommand registration regression
+# ============================================================================
+
+def test_f3_install_openclaw_registered_in_cli_help():
+    """`install-openclaw` must appear in the top-level --help output."""
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "--help"],
+        capture_output=True, text=True, timeout=15, cwd=str(REPO_ROOT),
+    )
+    assert "install-openclaw" in result.stdout
+
+
+def test_f3_all_install_subcommands_still_present():
+    """All prior install-* subcommands must still be registered — no regression
+    from adding install-openclaw."""
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "--help"],
+        capture_output=True, text=True, timeout=15, cwd=str(REPO_ROOT),
+    )
+    for cmd in ("install-cursor", "install-pi", "install-codex", "install-openclaw"):
+        assert cmd in result.stdout, f"Missing CLI subcommand: {cmd}"

--- a/world_model_server/adapters/openclaw/openclaw.json
+++ b/world_model_server/adapters/openclaw/openclaw.json
@@ -1,0 +1,13 @@
+{
+  "mcp": {
+    "servers": {
+      "world-model": {
+        "command": "/absolute/path/to/python3",
+        "args": ["-m", "world_model_server.server"],
+        "env": {
+          "WORLD_MODEL_DB_PATH": ".claude/world-model"
+        }
+      }
+    }
+  }
+}

--- a/world_model_server/cli.py
+++ b/world_model_server/cli.py
@@ -659,6 +659,90 @@ def export_claude_md_command(args):
     asyncio.run(run())
 
 
+def install_openclaw_command(args):
+    """Register world-model-mcp as an MCP server in OpenClaw's config.
+
+    Merges an entry into ~/.openclaw/openclaw.json under mcp.servers.world-model.
+    Preserves all other keys in the config file. Defaults --python to
+    sys.executable (absolute path) because OpenClaw's process spawn does
+    NOT inherit the shell PATH; a bare `python3` command fails probe
+    with "MCP error -32000: Connection closed". Verified against
+    OpenClaw 2026.6.11 (e085fa1) on macOS on 2026-07-01.
+    """
+    import json
+
+    config_path = Path(args.config_path).expanduser().resolve() if args.config_path else (
+        Path.home() / ".openclaw" / "openclaw.json"
+    )
+
+    python_bin = args.python or sys.executable
+    if not Path(python_bin).is_absolute():
+        console.print(
+            f"[red]--python must be an absolute path (got: {python_bin!r}).[/red]\n"
+            "OpenClaw's process spawn does not inherit shell PATH, so a bare "
+            "interpreter name will fail probe."
+        )
+        sys.exit(1)
+
+    db_path = args.db_path or ".claude/world-model"
+
+    server_entry = {
+        "command": python_bin,
+        "args": ["-m", "world_model_server.server"],
+        "env": {
+            "WORLD_MODEL_DB_PATH": db_path,
+        },
+    }
+
+    if config_path.exists():
+        try:
+            existing = json.loads(config_path.read_text())
+        except json.JSONDecodeError as exc:
+            console.print(
+                f"[red]Failed to parse {config_path} as JSON: {exc}[/red]\n"
+                "Fix the config file by hand or delete it and rerun."
+            )
+            sys.exit(1)
+    else:
+        existing = {}
+
+    if not isinstance(existing, dict):
+        console.print(f"[red]{config_path} did not parse as a JSON object; refusing to write.[/red]")
+        sys.exit(1)
+
+    mcp_block = existing.setdefault("mcp", {})
+    servers = mcp_block.setdefault("servers", {})
+
+    if "world-model" in servers and not args.force:
+        console.print(
+            f"[yellow]OpenClaw adapter already present at {config_path} "
+            "(mcp.servers.world-model)[/yellow]\n"
+            "Use --force to overwrite the existing entry."
+        )
+        return
+
+    if args.dry_run:
+        console.print(f"[bold]Would write to:[/bold] {config_path}")
+        console.print("\n--- proposed mcp.servers.world-model entry ---\n")
+        console.print(json.dumps(server_entry, indent=2))
+        return
+
+    servers["world-model"] = server_entry
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(existing, indent=2) + "\n")
+
+    console.print("[green]OpenClaw adapter installed[/green]")
+    console.print(f"  Wrote mcp.servers.world-model to {config_path}")
+    console.print(f"  command: {python_bin}")
+    console.print(f"  WORLD_MODEL_DB_PATH: {db_path}")
+    console.print(
+        "\nNext: verify with:\n  openclaw mcp probe world-model\n"
+        "You should see \"world-model: 27 tools\" (or however many the current "
+        "world-model-mcp version exposes)."
+    )
+
+
 def install_codex_command(args):
     """Wire world-model-mcp into Codex CLI by appending to ~/.codex/config.toml.
 
@@ -1056,6 +1140,37 @@ def main():
         help="Print what would be appended without writing",
     )
     codex_parser.set_defaults(func=install_codex_command)
+
+    openclaw_parser = subparsers.add_parser(
+        "install-openclaw",
+        help="Wire world-model-mcp into OpenClaw by merging into ~/.openclaw/openclaw.json",
+    )
+    openclaw_parser.add_argument(
+        "--config-path", type=str, default=None,
+        help="Override the OpenClaw config path (default: ~/.openclaw/openclaw.json)",
+    )
+    openclaw_parser.add_argument(
+        "--python", type=str, default=None,
+        help=(
+            "Absolute path to the python3 that has world-model-mcp installed. "
+            "Default: sys.executable (the interpreter running this CLI). "
+            "OpenClaw's process spawn does not inherit shell PATH, so this MUST "
+            "be an absolute path."
+        ),
+    )
+    openclaw_parser.add_argument(
+        "--db-path", type=str, default=None,
+        help="WORLD_MODEL_DB_PATH env value for the MCP server (default: .claude/world-model)",
+    )
+    openclaw_parser.add_argument(
+        "--force", action="store_true",
+        help="Overwrite the mcp.servers.world-model entry if already present",
+    )
+    openclaw_parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print what would be written without modifying the config file",
+    )
+    openclaw_parser.set_defaults(func=install_openclaw_command)
 
     status_watch_parser = subparsers.add_parser(
         "status-watch",


### PR DESCRIPTION
## Summary

First v0.10 adapter, per the roadmap locked after the 2026-06-30 Hermes/OpenClaw deep research: OpenClaw first, Hermes MCP second, Continue third.

Registers world-model-mcp as an external MCP server inside [OpenClaw](https://github.com/openclaw/openclaw) via `openclaw mcp add`. OpenClaw ships no native memory layer, so this is pure additive — all 26 world-model tools become available to OpenClaw agent turns without capability overlap.

**MCP-only in this cut.** Typed lifecycle hook integration (`before_prompt_build`, `before_tool_call`, `before_compaction`, `session_start`, ...) requires a TypeScript plugin bundle and is tracked as follow-up work in the adapter README and the v0.10 roadmap section.

## What's in this PR

- `adapters/openclaw/README.md` — install walkthrough, hook-mapping table, ClawMem comparison, caveats section, roadmap for `install-openclaw` CLI and TS plugin bundle
- `adapters/openclaw/openclaw.json` — bundled MCP server registration snippet for hand-editing users
- `README.md` — Option 7 install section + v0.10 roadmap entry marking OpenClaw MCP registration as shipped

Config path (`~/.openclaw/openclaw.json` under `mcp.servers`) verified against [docs.openclaw.ai/cli/mcp](https://docs.openclaw.ai/cli/mcp) on 2026-07-01.

## v0.10 follow-ups (tracked in adapter README, not in this PR)

- `install-openclaw` CLI subcommand for parity with `install-cursor` / `install-codex`
- OpenClaw plugin bundle (TypeScript) for typed lifecycle hooks — ships only if MCP-only adoption justifies the plugin work

## Positioning against ClawMem

[yoloshii/ClawMem](https://github.com/yoloshii/ClawMem) already ships a cross-runtime memory adapter for Claude Code + OpenClaw + Hermes against a shared SQLite vault. The adapter README leans into world-model-mcp's differentiation:

- per-fact provenance (`asserted_by`, `confirmer`, `confirmation_state`, `evidence_type`, `last_decay_at`)
- per-evidence-type decay half-lives (test 180d, bug_fix 365d, user_correction 730d, source_code 365d, session 14d)
- PreToolUse defer enforcement tier
- pre-registered SWE-bench Verified benchmark + Zenodo DOI 10.5281/zenodo.20834509

Not framed as a competitive takedown — just an honest side-by-side so users pick with eyes open.

## Test plan

- [x] JSON snippet parses (`python3 -c "import json; json.load(open('adapters/openclaw/openclaw.json'))"`)
- [x] Full test suite: 375/375 pass (no code changes to server, hooks, or helpers)
- [ ] Manual end-to-end verification against a real OpenClaw install (deferred — no OpenClaw install on the maintainer machine; adapter shape verified against docs only; PR notes call this out)
- [ ] Adapter marked "experimental" in README until at least one external user reports a working install (matches the cursor/codex adapter maturity trajectory)

## Related

- v0.10 roadmap: [`project_v010_adapter_roadmap.md`](https://github.com/SaravananJaichandar/world-model-mcp) (author memory, not in repo)
- Deep research synthesis dated 2026-06-30 sourced the OpenClaw / Hermes / ClawMem picture

🤖 Generated with [Claude Code](https://claude.com/claude-code)