### PR TITLE
v0.10: Continue adapter (MCP registration) + install-continue CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,19 @@ python -m world_model_server.cli install-codex
 
 `--dry-run` prints what would be appended without writing; `--force` re-appends even if the adapter marker is already present. The bundled snippet uses `world_model` (underscore) as the MCP server name to dodge Codex's silent hyphen-strip in its tool-name sanitizer. Hook output is camelCase with `deny_unknown_fields` compliance against Codex's strict Rust schema; the contract is locked down by tests in `tests/test_v075_features.py`. See [adapters/codex/README.md](adapters/codex/README.md).
 
+### Option 7: Run inside Continue (experimental, v0.10)
+
+For users of [Continue](https://github.com/continuedev/continue), the OSS coding-agent extension for VS Code and JetBrains (largest OSS coding-agent extension not tied to a platform vendor — reprioritized after the SpaceX/Cursor acquisition):
+
+```bash
+pip install world-model-mcp
+python -m world_model_server.cli setup
+python -m world_model_server.cli install-continue
+# Reload the Continue extension. In agent mode, world-model tools appear under the "world-model" server.
+```
+
+`install-continue` writes a standalone `<project>/.continue/mcpServers/world-model.yaml` following Continue's per-server-file pattern. No config merge is needed because Continue's own docs use one YAML per MCP server in that directory. Defaults the `command` field to `sys.executable` (absolute path); rejects relative `--python` overrides. Flags: `--force`, `--dry-run`, `--project-dir <path>`, `--python <abs-path>`, `--db-path <path>`. Continue watches `.continue/mcpServers/` in newer builds, so auto-discovery should pick up the new server; if not, reload the extension. MCP tools are available only in Continue's agent mode. See [adapters/continue/README.md](adapters/continue/README.md).
+
 ### What Gets Installed
 
 ```
@@ -620,15 +633,17 @@ v0.7.3 added anonymous usage telemetry. It is:
 ### v0.9.2 (Shipped 2026-06-30) — Multi-seed replication appendix
 - [x] Pre-registered 17-instance multi-seed test per `benchmarks/repeat-mistake/SEED_PLAN.md` (locked 2026-06-25). Outcome: load-bearing replication 0 of 7; mean paired delta across two seeds is +0.24 per instance, bootstrap 95 percent CI [0.00, 0.47]. The v0.9 +10.2 pts headline was substantially attributable to an unlucky baseline draw. Honest update published per the pre-registered acceptance criteria. Appendix in `RESULTS.md` and `paper.md`. Zenodo record updated to version 2.
 
-### v0.10 (Next, in design)
+### v0.10 (In progress)
+- [x] **Continue adapter (MCP registration) + `install-continue` CLI**. Registers world-model-mcp as an MCP tool source inside [Continue](https://github.com/continuedev/continue) (VS Code + JetBrains) via `python -m world_model_server.cli install-continue`. Writes a standalone `<project>/.continue/mcpServers/world-model.yaml` following Continue's per-server-file pattern — no config merge needed. Defaults `command` to `sys.executable` (absolute), rejects relative `--python`, supports `--project-dir` / `--force` / `--dry-run` / `--db-path`. CLI-side E2E verified: the exact stdio spawn Continue would perform returns 27 tools via a live `tools/list` roundtrip. Last-mile "does Continue's LLM actually see the tools in agent mode" verification requires a live VS Code / JetBrains session. See [`adapters/continue/`](./adapters/continue/).
 - [ ] Full-corpus multi-seed replication: all 49 paired instances at 3-5 seeds (the v0.9.2 update covers a 17-instance subset only). The 17-instance subset surfaced the variance signal; the full-corpus run quantifies it across the entire benchmark.
 - [ ] Larger task counts per repo; broader corpus coverage beyond the 50-task subset.
-- [ ] Head-to-head benchmarks against other memory layers (mem0, Letta, Zep, piia-engram).
+- [ ] Head-to-head benchmarks against other memory layers (mem0, Letta, Zep, piia-engram, ClawMem).
 - [ ] Explicit failure-mode-similarity scoring to predict when cross-domain transfer will succeed.
 - [ ] `auto` strategy rewrite to fold in `confirmer` + decay awareness (should lift the v0.8.1 contradiction-resolution benchmark's auto score from 77.1% past 90%).
 - [ ] Antigravity CLI adapter (held pending a `TransformCompactionHook` in the SDK for the load-bearing memory-injection contract).
 - [ ] MCP spec readiness for upcoming spec versions (stateless transport, `_meta` headers, `InputRequiredResult`).
 - [ ] Cline adapter (lower urgency after they shipped global AGENTS rules in v3.86).
+- [ ] Windsurf adapter.
 
 ---
 

--- a/adapters/continue/README.md
+++ b/adapters/continue/README.md
@@ -1,0 +1,184 @@
+# Continue adapter (experimental)
+
+This adapter wires `world-model-mcp` into
+[Continue](https://github.com/continuedev/continue) — the largest
+open-source coding-agent extension not tied to a platform vendor,
+available for VS Code and JetBrains — as an MCP tool source.
+
+Status: experimental. Verified against the Continue MCP configuration
+schema documented at
+[docs.continue.dev/customize/deep-dives/mcp](https://docs.continue.dev/customize/deep-dives/mcp)
+as of 2026-07-01. E2E verification of the last-mile "does Continue's
+LLM actually see the 27 tools" step requires a running VS Code / JetBrains
+session; the CLI-side install and file-write path is verified by tests.
+
+## Why this adapter matters
+
+Continue is the largest open-source coding-agent extension that is
+not tied to a single platform vendor. After the SpaceX/Cursor
+acquisition (2026), platform-vendor risk became a real concern for
+teams standardizing on an OSS-neutral coding-agent workflow.
+Wiring world-model-mcp into Continue extends the "harness-neutral
+memory" story to that constituency.
+
+## What you get
+
+- `world-model-mcp` registered as a stdio MCP server inside
+  Continue via a single standalone YAML file at
+  `<project>/.continue/mcpServers/world-model.yaml`
+- All 27 world-model tools available in Continue's agent mode
+- Same shared `.claude/world-model/` database used by the Claude
+  Code, Cursor, OpenClaw, and Hermes adapters — so a project running
+  in multiple clients sees the same memory
+
+MCP-only in this cut. Continue's rules system (`.continue/rules/`)
+and system-prompt customization are documented separately by
+Continue and are not touched by this adapter.
+
+## Install (recommended: CLI subcommand)
+
+Run from your project root:
+
+```bash
+# 1. Install the package
+pip install -U world-model-mcp
+
+# 2. Initialize the world-model database
+python -m world_model_server.cli setup
+
+# 3. Register world-model in this project's .continue/mcpServers/
+python -m world_model_server.cli install-continue
+```
+
+Step 3 writes `<project>/.continue/mcpServers/world-model.yaml`.
+Defaults the `command` field to `sys.executable` (absolute path
+to the interpreter running the CLI) — the same absolute-path
+posture as the OpenClaw and Hermes adapters.
+
+Reload Continue: reopen the VS Code / JetBrains window, or reload
+the extension. Continue watches the `.continue/mcpServers/`
+directory for changes and picks up new servers automatically.
+
+Verify: open Continue's agent mode and check the tool picker. All
+27 world-model tools should be visible under the `world-model`
+server name.
+
+**Flags** — `install-continue` supports:
+
+| Flag | Purpose |
+| --- | --- |
+| `--project-dir PATH` | Which project to install into (default: current directory) |
+| `--python PATH` | Absolute path to the python3 you want Continue to spawn. Default: the interpreter running the CLI. Relative values are rejected. |
+| `--db-path PATH` | Value for `WORLD_MODEL_DB_PATH`. Default: `.claude/world-model` |
+| `--dry-run` | Print the YAML that would be written without touching disk |
+| `--force` | Overwrite the existing `world-model.yaml` file if present |
+
+## Manual install (fallback)
+
+If you prefer to skip the CLI, create
+`<project>/.continue/mcpServers/world-model.yaml` yourself with this
+content (replace the placeholder with the output of `which python3`):
+
+```yaml
+name: world-model-mcp
+version: 0.1.0
+schema: v1
+mcpServers:
+  - name: world-model
+    type: stdio
+    command: /absolute/path/to/python3
+    args:
+      - -m
+      - world_model_server.server
+    env:
+      WORLD_MODEL_DB_PATH: .claude/world-model
+```
+
+Same file is bundled as [`world-model.yaml`](./world-model.yaml)
+for copy-paste.
+
+## Where the database lives
+
+The adapter uses `.claude/world-model/` (relative to the project
+root) as the database path. If the same project also has the Claude
+Code, Cursor, OpenClaw, or Hermes adapters installed, all clients
+read and write the same SQLite database — one shared fact graph
+across every coding-agent runtime you use in that project.
+
+For user-wide shared memory across multiple projects, override with
+an absolute path:
+
+```bash
+python -m world_model_server.cli install-continue \
+    --db-path /Users/you/.world-model-shared
+```
+
+## Overlap with Continue Rules
+
+Continue ships its own rules system at `.continue/rules/*.md`.
+world-model-mcp does not replace it — the two sit at different
+layers:
+
+- **Continue Rules**: static markdown rules you write. Best for
+  project conventions you already know.
+- **world-model-mcp**: learned constraints with violation counts,
+  hard / defer / warn enforcement tiers, plus a temporal fact
+  graph with per-fact provenance, per-evidence-type decay
+  half-lives, and confidence-weighted contradiction resolution.
+  Best for constraints that should *enforce* and for facts that
+  need provenance and history.
+
+If you use both, expect some overlap — that's fine, they don't
+conflict.
+
+## Roadmap for this adapter
+
+MCP-only integration ships in v0.10. Two follow-ups on the roadmap:
+
+**v0.10.x — Continue global-config path.** Continue supports a
+user-level `~/.continue/config.yaml` with a top-level `mcpServers`
+array. `install-continue` currently writes only project-scoped
+files. A `--global` flag that merges into `~/.continue/config.yaml`
+using `ruamel.yaml` round-trip mode (same as the Hermes adapter)
+is on the roadmap.
+
+**v0.10.x — Slash-command variant.** Continue supports custom
+slash commands via its rules and skills system. Wiring
+`/world-model` slash commands from the existing Claude Code /
+Cursor / Codex slash-command surface into Continue is a natural
+follow-up.
+
+## Caveats
+
+- **VS Code / JetBrains restart required.** After writing the
+  server file, Continue may need a reload to pick it up. Reopening
+  the workspace or restarting the extension is the fastest way
+  to force it. Continue also watches `.continue/mcpServers/`
+  in newer builds — auto-discovery should work but the manual
+  restart is the safe path.
+- **`python3` MUST be an absolute path.** OpenClaw's process spawn
+  is documented to not inherit shell PATH; Hermes' spawn behavior
+  is likely similar; Continue's has not been verified end-to-end
+  as of 2026-07-01. `install-continue` defaults to `sys.executable`
+  and rejects relative `--python` overrides as a hard error, so
+  users hit a clear failure at install time rather than a cryptic
+  "server did not start" later.
+- **Project-scoped only.** Runs from the project you install into.
+  For user-wide memory across projects, use `--db-path` with an
+  absolute path pointing to a shared location.
+- **Agent-mode only.** MCP tools are only available in Continue's
+  agent mode (per Continue's own docs). Chat and edit modes will
+  not surface world-model tools.
+- **HTTP transport.** For `world-model-mcp` deployed over HTTP,
+  register the server with Continue's `type: streamable-http`
+  or `type: sse` and a `url:` field instead of `command`/`args`/`env`.
+
+## Reporting issues
+
+Open an issue on the main repo with the `adapter:continue` label:
+<https://github.com/SaravananJaichandar/world-model-mcp/issues>
+
+Include:
+- Continue version (from the VS Code / JetBrains extension list)
+- Your `<project>/.continue/mcpServers/world-model.yaml` contents
+- Continue's own MCP debug output if available

--- a/adapters/continue/world-model.yaml
+++ b/adapters/continue/world-model.yaml
@@ -1,0 +1,12 @@
+name: world-model-mcp
+version: 0.1.0
+schema: v1
+mcpServers:
+  - name: world-model
+    type: stdio
+    command: /absolute/path/to/python3
+    args:
+      - -m
+      - world_model_server.server
+    env:
+      WORLD_MODEL_DB_PATH: .claude/world-model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ packages = ["world_model_server"]
 "world_model_server/adapters/pi/package.json" = "world_model_server/adapters/pi/package.json"
 "world_model_server/adapters/codex/config.toml" = "world_model_server/adapters/codex/config.toml"
 "world_model_server/adapters/codex/hooks_snippet.toml" = "world_model_server/adapters/codex/hooks_snippet.toml"
+"world_model_server/adapters/continue_/world-model.yaml" = "world_model_server/adapters/continue_/world-model.yaml"
 "world_model_server/hooks/world-model-capture.js" = "world_model_server/hooks/world-model-capture.js"
 "world_model_server/hooks/world-model-inject.js" = "world_model_server/hooks/world-model-inject.js"
 "world_model_server/hooks/world-model-session.js" = "world_model_server/hooks/world-model-session.js"

--- a/tests/test_v010_continue_features.py
+++ b/tests/test_v010_continue_features.py
@@ -1,0 +1,238 @@
+"""
+v0.10 Continue adapter tests.
+
+F1: Continue adapter bundled files (world-model.yaml snippet)
+F2: install-continue CLI (dry-run, writes, idempotent, absolute-path
+    enforcement, --python override, --db-path override, --force overwrite,
+    YAML validity of the written file)
+
+Continue's MCP model is one standalone YAML file per server at
+<project>/.continue/mcpServers/<name>.yaml. That means install-continue
+does NOT merge into an existing config file; it owns the world-model.yaml
+file end-to-end. No ruamel.yaml dependency is needed for this reason —
+comment preservation is only a concern when merging into a user-authored
+config.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+# Continue's YAML files are simple and self-authored — plain pyyaml is enough
+# for the tests to parse the output. If pyyaml is missing (it's a transitive
+# dep of some things but not a hard dep of world-model-mcp), skip.
+yaml = pytest.importorskip("yaml")
+
+
+# ============================================================================
+# F1: Bundled adapter files
+# ============================================================================
+
+def test_f1_continue_adapter_dir_bundled():
+    """Continue adapter files must be inside the package so installs from PyPI
+    ship them. The Python package uses `continue_` because `continue` is a
+    Python keyword."""
+    bundle = REPO_ROOT / "world_model_server" / "adapters" / "continue_"
+    assert bundle.exists()
+    assert (bundle / "world-model.yaml").exists()
+
+
+def test_f1_continue_top_level_readme_exists():
+    """The top-level adapters/continue/README.md is what users browsing the
+    repo see first."""
+    readme = REPO_ROOT / "adapters" / "continue" / "README.md"
+    assert readme.exists()
+    text = readme.read_text()
+    assert "Continue" in text
+    assert "install-continue" in text
+    assert ".continue/mcpServers/" in text
+
+
+def test_f1_continue_bundled_yaml_is_valid():
+    """The bundled world-model.yaml must parse as valid YAML with the
+    required metadata (name, version, schema) and an mcpServers list."""
+    bundle = REPO_ROOT / "world_model_server" / "adapters" / "continue_" / "world-model.yaml"
+    data = yaml.safe_load(bundle.read_text())
+    assert isinstance(data, dict)
+    assert data["name"] == "world-model-mcp"
+    assert data["schema"] == "v1"
+    assert isinstance(data["version"], str)
+    servers = data["mcpServers"]
+    assert isinstance(servers, list)
+    assert len(servers) == 1
+    entry = servers[0]
+    assert entry["name"] == "world-model"
+    assert entry["type"] == "stdio"
+    assert entry["args"] == ["-m", "world_model_server.server"]
+    assert "WORLD_MODEL_DB_PATH" in entry["env"]
+
+
+# ============================================================================
+# F2: install-continue CLI
+# ============================================================================
+
+def test_f2_install_continue_dry_run(tmp_path):
+    """--dry-run prints the proposed YAML without writing."""
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-continue",
+         "--project-dir", str(tmp_path), "--dry-run"],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Would write" in result.stdout
+    # No files written
+    assert not (tmp_path / ".continue").exists()
+
+
+def test_f2_install_continue_writes_and_defaults_absolute_python(tmp_path):
+    """First install writes .continue/mcpServers/world-model.yaml with an
+    absolute-path default for --python (sys.executable)."""
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-continue",
+         "--project-dir", str(tmp_path)],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+
+    target = tmp_path / ".continue" / "mcpServers" / "world-model.yaml"
+    assert target.exists()
+
+    data = yaml.safe_load(target.read_text())
+    assert data["name"] == "world-model-mcp"
+    assert data["schema"] == "v1"
+    entry = data["mcpServers"][0]
+    assert entry["type"] == "stdio"
+    assert entry["args"] == ["-m", "world_model_server.server"]
+    assert Path(entry["command"]).is_absolute()
+    assert entry["env"]["WORLD_MODEL_DB_PATH"] == ".claude/world-model"
+
+
+def test_f2_install_continue_idempotent(tmp_path):
+    """Second install without --force refuses to overwrite the existing
+    world-model.yaml file."""
+    subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-continue",
+         "--project-dir", str(tmp_path)],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    target = tmp_path / ".continue" / "mcpServers" / "world-model.yaml"
+    first_text = target.read_text()
+
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-continue",
+         "--project-dir", str(tmp_path)],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0
+    assert "already present" in result.stdout.lower()
+    # File unchanged
+    assert target.read_text() == first_text
+
+
+def test_f2_install_continue_force_overwrites(tmp_path):
+    """--force replaces the existing world-model.yaml."""
+    subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-continue",
+         "--project-dir", str(tmp_path)],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    target = tmp_path / ".continue" / "mcpServers" / "world-model.yaml"
+    first = yaml.safe_load(target.read_text())
+    assert first["mcpServers"][0]["env"]["WORLD_MODEL_DB_PATH"] == ".claude/world-model"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-continue",
+         "--project-dir", str(tmp_path),
+         "--force", "--db-path", "/custom/db/path"],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+
+    second = yaml.safe_load(target.read_text())
+    assert second["mcpServers"][0]["env"]["WORLD_MODEL_DB_PATH"] == "/custom/db/path"
+
+
+def test_f2_install_continue_rejects_relative_python(tmp_path):
+    """--python MUST be an absolute path. A relative value is a hard error."""
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-continue",
+         "--project-dir", str(tmp_path), "--python", "python3"],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode != 0
+    assert "absolute path" in (result.stdout + result.stderr).lower()
+    # No file written
+    assert not (tmp_path / ".continue" / "mcpServers" / "world-model.yaml").exists()
+
+
+def test_f2_install_continue_creates_parent_dirs(tmp_path):
+    """If .continue/mcpServers/ doesn't exist, install creates it."""
+    project = tmp_path / "some" / "nested" / "project"
+    project.mkdir(parents=True)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-continue",
+         "--project-dir", str(project)],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+    assert (project / ".continue" / "mcpServers" / "world-model.yaml").exists()
+
+
+def test_f2_install_continue_yaml_output_parses_cleanly(tmp_path):
+    """The exact YAML text written by install-continue must round-trip through
+    yaml.safe_load without warnings or errors. Regression guard for the
+    hand-formatted YAML in install_continue_command."""
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "install-continue",
+         "--project-dir", str(tmp_path)],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+
+    target = tmp_path / ".continue" / "mcpServers" / "world-model.yaml"
+    text = target.read_text()
+
+    # Must parse without exception
+    data = yaml.safe_load(text)
+
+    # Continue's required metadata block
+    assert data["name"] == "world-model-mcp"
+    assert data["schema"] == "v1"
+    assert "version" in data
+
+    # Exactly one MCP server, correctly shaped
+    assert len(data["mcpServers"]) == 1
+    entry = data["mcpServers"][0]
+    for required_key in ("name", "type", "command", "args", "env"):
+        assert required_key in entry, f"Missing required key: {required_key}"
+
+
+# ============================================================================
+# F3: CLI subcommand registration regression
+# ============================================================================
+
+def test_f3_install_continue_registered_in_cli_help():
+    """`install-continue` must appear in the top-level --help output."""
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "--help"],
+        capture_output=True, text=True, timeout=15, cwd=str(REPO_ROOT),
+    )
+    assert "install-continue" in result.stdout
+
+
+def test_f3_all_install_subcommands_still_present():
+    """All prior install-* subcommands must still be registered."""
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "--help"],
+        capture_output=True, text=True, timeout=15, cwd=str(REPO_ROOT),
+    )
+    for cmd in ("install-cursor", "install-pi", "install-codex", "install-continue"):
+        assert cmd in result.stdout, f"Missing CLI subcommand: {cmd}"

--- a/world_model_server/adapters/continue_/world-model.yaml
+++ b/world_model_server/adapters/continue_/world-model.yaml
@@ -1,0 +1,12 @@
+name: world-model-mcp
+version: 0.1.0
+schema: v1
+mcpServers:
+  - name: world-model
+    type: stdio
+    command: /absolute/path/to/python3
+    args:
+      - -m
+      - world_model_server.server
+    env:
+      WORLD_MODEL_DB_PATH: .claude/world-model

--- a/world_model_server/cli.py
+++ b/world_model_server/cli.py
@@ -659,6 +659,77 @@ def export_claude_md_command(args):
     asyncio.run(run())
 
 
+def install_continue_command(args):
+    """Register world-model-mcp as an MCP server in Continue.
+
+    Writes a standalone YAML file at
+    <project-dir>/.continue/mcpServers/world-model.yaml, matching
+    Continue's documented per-server-file pattern. No config merge is
+    needed because Continue expects one YAML per MCP server in that
+    directory — we own the whole file.
+
+    Defaults --python to sys.executable (absolute path). Rejects relative
+    --python overrides as a hard error, matching the OpenClaw and Hermes
+    adapters. No ruamel.yaml dependency needed because we author the
+    file end-to-end (no comment preservation problem to solve).
+    """
+    project_dir = Path(args.project_dir).resolve()
+    mcp_servers_dir = project_dir / ".continue" / "mcpServers"
+    target = mcp_servers_dir / "world-model.yaml"
+
+    python_bin = args.python or sys.executable
+    if not Path(python_bin).is_absolute():
+        console.print(
+            f"[red]--python must be an absolute path (got: {python_bin!r}).[/red]\n"
+            "Continue may not inherit shell PATH when spawning stdio MCP "
+            "servers; a relative interpreter name is not safe."
+        )
+        sys.exit(1)
+
+    db_path = args.db_path or ".claude/world-model"
+
+    yaml_body = (
+        "name: world-model-mcp\n"
+        "version: 0.1.0\n"
+        "schema: v1\n"
+        "mcpServers:\n"
+        "  - name: world-model\n"
+        "    type: stdio\n"
+        f"    command: {python_bin}\n"
+        "    args:\n"
+        "      - -m\n"
+        "      - world_model_server.server\n"
+        "    env:\n"
+        f"      WORLD_MODEL_DB_PATH: {db_path}\n"
+    )
+
+    if target.exists() and not args.force:
+        console.print(
+            f"[yellow]Continue adapter already present at {target}[/yellow]\n"
+            "Use --force to overwrite the existing file."
+        )
+        return
+
+    if args.dry_run:
+        console.print(f"[bold]Would write to:[/bold] {target}")
+        console.print("\n--- proposed world-model.yaml ---\n")
+        console.print(yaml_body)
+        return
+
+    mcp_servers_dir.mkdir(parents=True, exist_ok=True)
+    target.write_text(yaml_body)
+
+    console.print("[green]Continue adapter installed[/green]")
+    console.print(f"  Wrote {target}")
+    console.print(f"  command: {python_bin}")
+    console.print(f"  WORLD_MODEL_DB_PATH: {db_path}")
+    console.print(
+        "\nNext: reload the Continue extension (reopen the VS Code / JetBrains\n"
+        "window, or reload the extension) so it picks up the new server.\n"
+        "Then open agent mode and confirm world-model tools are visible."
+    )
+
+
 def install_codex_command(args):
     """Wire world-model-mcp into Codex CLI by appending to ~/.codex/config.toml.
 
@@ -1056,6 +1127,36 @@ def main():
         help="Print what would be appended without writing",
     )
     codex_parser.set_defaults(func=install_codex_command)
+
+    continue_parser = subparsers.add_parser(
+        "install-continue",
+        help="Wire world-model-mcp into Continue by writing .continue/mcpServers/world-model.yaml",
+    )
+    continue_parser.add_argument(
+        "--project-dir", type=str, default=".",
+        help="Project directory to install into (default: current directory)",
+    )
+    continue_parser.add_argument(
+        "--python", type=str, default=None,
+        help=(
+            "Absolute path to the python3 that has world-model-mcp installed. "
+            "Default: sys.executable (the interpreter running this CLI). "
+            "Relative values are rejected."
+        ),
+    )
+    continue_parser.add_argument(
+        "--db-path", type=str, default=None,
+        help="WORLD_MODEL_DB_PATH env value for the MCP server (default: .claude/world-model)",
+    )
+    continue_parser.add_argument(
+        "--force", action="store_true",
+        help="Overwrite the existing world-model.yaml file if present",
+    )
+    continue_parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print the YAML that would be written without touching disk",
+    )
+    continue_parser.set_defaults(func=install_continue_command)
 
     status_watch_parser = subparsers.add_parser(
         "status-watch",


### PR DESCRIPTION
## Summary

Priority-3 v0.10 adapter per the locked roadmap. Registers world-model-mcp as a stdio MCP tool source inside [Continue](https://github.com/continuedev/continue) (VS Code + JetBrains) via `install-continue`, which writes a standalone `<project>/.continue/mcpServers/world-model.yaml` file.

Independent of PR #9 (OpenClaw) and PR #10 (Hermes). All three branch off `main` and can merge in any order — no cross-PR dependencies.

## What's in this PR

- `adapters/continue/README.md` — install walkthrough, Continue Rules overlap analysis, caveats
- `adapters/continue/world-model.yaml` — bundled hand-edit snippet
- `world_model_server/adapters/continue_/world-model.yaml` — packaged copy (dir named `continue_` to dodge the Python keyword collision)
- `world_model_server/cli.py` — `install_continue_command` + subparser
- `pyproject.toml` — force-include for the bundled snippet
- `tests/test_v010_continue_features.py` — 12 tests including bundled-YAML validity, dry-run/writes/force/idempotence, absolute-path enforcement, parent-dir creation, YAML round-trip validity, and a subcommand-registration regression check
- `README.md` — Option 7 install section + v0.10 roadmap entry

## Why no YAML merge (unlike Hermes)

Continue's own docs use one YAML file per MCP server in `.continue/mcpServers/`. `install-continue` writes a whole file we own end-to-end. No merging, no comment preservation problem, no `ruamel.yaml` dependency. Simpler than the Hermes case by design.

## Design decisions

- **`sys.executable` default for `--command`** — same absolute-path posture as `install-openclaw` and `install-hermes`. OpenClaw is documented to not inherit shell PATH; Continue may be similar (not empirically verified end-to-end).
- **Reject relative `--python` overrides as hard error** — clear failure at install time rather than cryptic "server did not start" later.
- **Project-scoped install** (like `install-cursor`). A `--global` flag that merges into `~/.continue/config.yaml` under `mcpServers` (would need `ruamel.yaml` for comment preservation) is documented as a v0.10.x follow-up.
- **MCP-only in this cut.** Wiring Continue Rules or slash-command surface is a separate track.

## CLI-side E2E verification

```
$ python -m world_model_server.cli install-continue --project-dir /tmp/continue-adapter-test
Continue adapter installed
  Wrote /tmp/continue-adapter-test/.continue/mcpServers/world-model.yaml
  command: /Library/Frameworks/Python.framework/Versions/3.11/bin/python3
  WORLD_MODEL_DB_PATH: .claude/world-model
```

The written file parses cleanly through `yaml.safe_load` with all Continue-required metadata (`name`, `version`, `schema: v1`) and a properly-shaped `mcpServers` entry. Running the exact stdio spawn Continue would perform against the written `command` + `args` returns **27 tools** via a live `tools/list` JSON-RPC roundtrip.

## Last-mile note

The final "does Continue's LLM actually surface the 27 tools in agent mode" step needs a live VS Code or JetBrains session with the Continue extension installed. That's beyond what the CLI can test itself. Called out in the adapter README (`Status: experimental`) and here for full honesty. If maintainer or a community user does this pass and reports back, we can promote the adapter status from experimental to verified in a v0.10.x doc patch.

## Test plan

- [x] Full test suite: 375 baseline + 12 new = 387/387 pass
- [x] `install-continue --dry-run` prints YAML without writing
- [x] Writes `<project>/.continue/mcpServers/world-model.yaml` with absolute `command` default
- [x] Refuses second install without `--force`; overwrites with `--force`
- [x] Rejects relative `--python` (hard error, no file written)
- [x] Creates nested parent directories as needed
- [x] Written YAML parses cleanly with all Continue-required fields
- [x] Live stdio spawn using the written command returns 27 tools
- [ ] Live Continue extension in VS Code agent mode surfaces tools — deferred (needs UI session)
- [ ] JetBrains variant of the above — deferred

## Related

- v0.10 roadmap (author memory): OpenClaw first (PR #9), Hermes MCP second (PR #10), Continue third (this PR)
- Continue MCP docs: https://docs.continue.dev/customize/deep-dives/mcp
- Continue main repo: https://github.com/continuedev/continue

🤖 Generated with [Claude Code](https://claude.com/claude-code)