### PR TITLE
v0.11.1: content-type routing schema field (nullable, additive)

### DIFF
--- a/tests/test_v0111_content_type.py
+++ b/tests/test_v0111_content_type.py
@@ -1,0 +1,151 @@
+"""
+v0.11.1: content-type routing schema field tests.
+
+The v0.11.1 patch adds a nullable `content_type` field to the Fact model
+and the facts table, distinguishing rules (always-inject), facts
+(search-on-demand), and procedures (multi-step workflows). Motivation is
+the write-side routing gap surfaced by Hermes #47349: a MemoryProvider
+needs an intelligent routing rule per write, and the schema is where
+that rule lives.
+
+Regression discipline:
+  - Nullable column, NULL default. Existing rows (which have NULL) are
+    unaffected. No backfill. Existing code paths that don't consume
+    content_type keep working exactly as before.
+  - Migration is idempotent: running `_run_migrations` twice on a DB
+    that already has the column is a no-op.
+  - Full v0.11 pydantic Fact model accepts existing serialized rows
+    without the new field.
+  - Full v0.11 pydantic Fact model accepts new rows with each of the
+    three enum values.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from world_model_server.knowledge_graph import KnowledgeGraph
+from world_model_server.models import Fact
+
+
+# ============================================================================
+# F1: Fact model accepts and rejects content_type values correctly
+# ============================================================================
+
+
+def test_f1_fact_model_content_type_defaults_to_none():
+    """Legacy code that constructs Fact without content_type must still work."""
+    f = Fact(fact_text="X", evidence_path="p")
+    assert f.content_type is None
+
+
+def test_f1_fact_model_content_type_accepts_rule():
+    f = Fact(fact_text="X", evidence_path="p", content_type="rule")
+    assert f.content_type == "rule"
+
+
+def test_f1_fact_model_content_type_accepts_fact():
+    f = Fact(fact_text="X", evidence_path="p", content_type="fact")
+    assert f.content_type == "fact"
+
+
+def test_f1_fact_model_content_type_accepts_procedure():
+    f = Fact(fact_text="X", evidence_path="p", content_type="procedure")
+    assert f.content_type == "procedure"
+
+
+def test_f1_fact_model_rejects_unknown_content_type():
+    """Literal type enforces the enum; unknown values raise."""
+    with pytest.raises(Exception):
+        Fact(fact_text="X", evidence_path="p", content_type="not-a-real-type")
+
+
+def test_f1_fact_model_serialization_round_trip():
+    """v0.11 Fact instances round-trip through JSON without losing content_type."""
+    original = Fact(fact_text="X", evidence_path="p", content_type="rule")
+    serialized = original.model_dump()
+    round_tripped = Fact(**serialized)
+    assert round_tripped.content_type == "rule"
+
+
+# ============================================================================
+# F2: Migration adds the column exactly once and is idempotent
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_f2_migration_adds_content_type_column(tmp_path):
+    """A fresh DB gets the content_type column via _run_migrations."""
+    kg = KnowledgeGraph(str(tmp_path / "wm"))
+    await kg.initialize()
+
+    async with aiosqlite.connect(kg.facts_db) as db:
+        cursor = await db.execute("PRAGMA table_info(facts)")
+        rows = await cursor.fetchall()
+        cols = {row[1] for row in rows}
+
+    assert "content_type" in cols
+
+
+@pytest.mark.asyncio
+async def test_f2_migration_is_idempotent(tmp_path):
+    """Running initialize twice on the same path does not error and does
+    not create duplicate columns."""
+    kg1 = KnowledgeGraph(str(tmp_path / "wm"))
+    await kg1.initialize()
+
+    # Second initialize: should be a no-op for the content_type column
+    kg2 = KnowledgeGraph(str(tmp_path / "wm"))
+    await kg2.initialize()
+
+    async with aiosqlite.connect(kg2.facts_db) as db:
+        cursor = await db.execute("PRAGMA table_info(facts)")
+        rows = await cursor.fetchall()
+        matches = [row for row in rows if row[1] == "content_type"]
+
+    assert len(matches) == 1
+
+
+@pytest.mark.asyncio
+async def test_f2_migration_creates_content_type_index(tmp_path):
+    """Index on content_type is created (needed for future routing filters)."""
+    kg = KnowledgeGraph(str(tmp_path / "wm"))
+    await kg.initialize()
+
+    async with aiosqlite.connect(kg.facts_db) as db:
+        cursor = await db.execute("SELECT name FROM sqlite_master WHERE type='index'")
+        rows = await cursor.fetchall()
+        indexes = {row[0] for row in rows}
+
+    assert "idx_facts_content_type" in indexes
+
+
+# ============================================================================
+# F3: NULL content_type on read is well-behaved (backward compatibility)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_f3_existing_rows_without_content_type_still_readable(tmp_path):
+    """Legacy rows (inserted without content_type) can be read back and the
+    field surfaces as None. This is the load-bearing backward-compat guarantee."""
+    kg = KnowledgeGraph(str(tmp_path / "wm"))
+    await kg.initialize()
+
+    fact = Fact(
+        id="legacy-1",
+        fact_text="A legacy fact from before v0.11.1",
+        evidence_path="p",
+    )
+    await kg.create_fact(fact)
+
+    round_tripped = await kg.get_fact_by_id("legacy-1")
+    assert round_tripped is not None
+    # The row exists, and any consumer reading content_type sees None or the
+    # absence of the field. The knowledge_graph.get_fact_by_id returns a dict
+    # (not a pydantic model), so we check for the key gracefully.
+    assert round_tripped.get("content_type") is None

--- a/world_model_server/knowledge_graph.py
+++ b/world_model_server/knowledge_graph.py
@@ -155,6 +155,18 @@ class KnowledgeGraph:
                 await db.execute(
                     "ALTER TABLE facts ADD COLUMN last_decay_at TIMESTAMP"
                 )
+            # v0.11.1: content-type axis for routing rules vs facts vs
+            # procedures. NULL default = legacy row / unclassified; no
+            # backfill. See adapters/hermes-memory-provider/README.md and
+            # the write-side routing discussion in Hermes #47349 for the
+            # architectural motivation.
+            if "content_type" not in cols:
+                await db.execute(
+                    "ALTER TABLE facts ADD COLUMN content_type TEXT"
+                )
+                await db.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_facts_content_type ON facts(content_type)"
+                )
             # Always backfill any NULL content_hash rows (covers post-migration inserts too)
             cursor = await db.execute(
                 "SELECT id, fact_text, evidence_path FROM facts WHERE content_hash IS NULL"

--- a/world_model_server/models.py
+++ b/world_model_server/models.py
@@ -98,6 +98,23 @@ class Fact(BaseModel):
             "computed on next read."
         ),
     )
+    # v0.11.1: content-type routing axis. Distinct from evidence_type
+    # (which describes where the fact came from) — content_type
+    # describes what shape of content this fact carries, so a
+    # MemoryProvider can route writes intelligently:
+    #   rule       — always-inject constraint (e.g., "always await async")
+    #   fact       — search-on-demand knowledge (e.g., "endpoint /users needs JWT")
+    #   procedure  — multi-step workflow (e.g., a runbook or skill definition)
+    # NULL = legacy row / unclassified. NULL-tolerant on read; existing
+    # code paths ignore it. See adapters/hermes-memory-provider/README.md.
+    content_type: Optional[Literal["rule", "fact", "procedure"]] = Field(
+        None,
+        description=(
+            "Content-type routing axis: 'rule' (always-inject), 'fact' "
+            "(search-on-demand), 'procedure' (multi-step workflow). NULL = "
+            "unclassified; write paths do not require this field."
+        ),
+    )
 
     class Config:
         json_schema_extra = {


### PR DESCRIPTION
## Summary

Adds a nullable `content_type` field to the `Fact` model and the facts table, distinguishing rules / facts / procedures. **Purely additive**: no existing code path changes, no backfill, migration is idempotent, and the field defaults to `NULL` for both legacy rows and new callers that do not specify it.

## Why

From the Hermes #47349 exchange: a `MemoryProvider` needs an intelligent routing rule per write:
- **rule** → always-inject store (constraints)
- **fact** → search-on-demand store (knowledge)
- **procedure** → skills store (multi-step workflows)

The current schema has `evidence_type` (where the fact came from) but no rules-vs-facts-vs-procedures axis (what shape of content it carries). v0.11.1 adds that axis without touching anything else.

## What's in this PR

- `world_model_server/models.py` — `Fact.content_type: Optional[Literal["rule", "fact", "procedure"]] = None` with docstring explaining routing intent
- `world_model_server/knowledge_graph.py` — `_run_migrations` adds `ALTER TABLE facts ADD COLUMN content_type TEXT` behind an existence check + creates `idx_facts_content_type` for future routing filters. Same idempotence pattern as v0.7.0 / v0.8.0 provenance migrations.
- `tests/test_v0111_content_type.py` — 10 tests covering:
  - F1 (Model): accepts None default + each enum value, rejects unknown values, round-trips through JSON
  - F2 (Migration): adds the column on a fresh DB, idempotent on second initialize, creates the index
  - F3 (Backward-compat): NULL content_type on read is well-behaved for legacy rows

## Regression discipline

- **448/448 tests pass** (438 before + 10 new). Zero regressions.
- v0.8.1 contradiction benchmark: **auto still 100.0%**.
- **No changes to `tools.py`, no changes to `server.py`, no changes to any hook wrappers or adapter code.**
- Every existing `Fact` row (with NULL content_type) reads back the same as before; every existing consumer either sees `content_type` as None or simply does not read the field.

## What v0.11.1 does NOT include (deferred)

Scoped intentionally to keep the diff small and the regression surface minimal:

- Consuming `content_type` in `query_fact` (routing filter) — deferred
- Consuming `content_type` in the Hermes MemoryProvider `handle_tool_call` dispatch — needs PR #16 merged first
- Backfill heuristic to infer `content_type` on existing rows — would need a classifier; safer to leave NULL and let the ecosystem opt in over time

## v0.11 roadmap position

- **v0.11.0 A: auto strategy rewrite** — merged (PR #15)
- **v0.11.0 B: Hermes MemoryProvider plugin** — open (PR #16)
- **v0.11.1: this PR** — schema field only, no consumer changes
- **v0.11.2: Dogfooding case study** — pending

## Test plan

- [x] Full test suite: 448/448 pass
- [x] New content-type tests: 10/10 pass
- [x] v0.8.1 contradiction benchmark: auto 105/105 (100.0%)
- [x] `Fact()` without `content_type` still constructs, matching legacy code
- [x] `Fact(..., content_type="rule")` / `"fact"` / `"procedure"` all validate
- [x] `Fact(..., content_type="not-real")` raises pydantic ValidationError
- [x] `KnowledgeGraph.initialize()` twice on the same DB does not duplicate the column
- [x] `idx_facts_content_type` created

## Related

- [Hermes #47349](https://github.com/NousResearch/hermes-agent/issues/47349) — the exchange that motivated the content-type axis
- PR #16 — Hermes MemoryProvider plugin (will consume this field in a v0.11.x follow-up)
- v0.11 roadmap in `README.md` "v0.11 (Planned) — Depth after breadth"

🤖 Generated with [Claude Code](https://claude.com/claude-code)