### PR TITLE
chore: register world-model-mcp as project MCP server for this repo (.mcp.json)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "world-model": {
+      "command": "python3",
+      "args": ["-m", "world_model_server.server"],
+      "env": {
+        "WORLD_MODEL_DB_PATH": ".claude/world-model"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `.mcp.json` at the repo root so Claude Code sessions working on this repo can call world-model tools via MCP.

**Motivation** — the v0.11.2 dogfooding case study (PR #18) exposed that `events`, `decisions`, and `sessions` tables in `.claude/world-model/` are all empty. Root cause: `.claude/settings.json` wired the four lifecycle hooks correctly and the hook scripts exist under `.claude/hooks/`, but this repo had no `.mcp.json` declaring world-model-mcp as an active MCP server. Without that declaration, Claude Code cannot reach the MCP tools the hooks need to write session / event / decision rows, and the hook wrappers fail-open (by design, to avoid blocking edits) — so the whole write path degraded silently to zero captures.

## What this fixes

- Going forward: future Claude Code sessions on this repo will start populating `events` / `decisions` / `sessions` rows through the normal capture path
- The tool now dogfoods on its own maintainer's workflow instead of only running the seeder once

## What this does NOT do

- Does not backfill any missing data. The tables remain empty in the shipped v0.11.2 case study snapshot (PR #18) — the case study reports the state as of publication.
- Does not modify PR #18's `CASE_STUDY.md`. That writeup describes the state at the time of publication; the fix is separate context.
- Does not add a `world-model doctor` command that would catch this class of misconfiguration proactively. Tracked as a v0.12 follow-up.

## The one line that matters

```json
{
  "mcpServers": {
    "world-model": {
      "command": "python3",
      "args": ["-m", "world_model_server.server"],
      "env": {
        "WORLD_MODEL_DB_PATH": ".claude/world-model"
      }
    }
  }
}
```

Uses bare `python3` (this repo is a Python-development environment; contributors have it on PATH), and a relative `WORLD_MODEL_DB_PATH` (resolves against Claude Code's working directory, matching the v0.10 install-* adapter convention).

## Regression discipline

- **448/448 tests pass** on this branch (branched off main pre-PR #18; will become 457/457 after #18 merges)
- v0.8.1 contradiction benchmark: **auto still 100.0%**
- JSON validates cleanly via `json.load`
- **No code changes. No test changes.** New file is only read by Claude Code when it initializes MCP connections; nothing in the shipped Python package or test suite reads it.

## Product observation this raises (for v0.12+)

The failure mode this commit fixes was invisible: hooks were wired, the maintainer trusted the capture path, and the tables just quietly stayed empty. That is a real UX gap — every user who installs world-model-mcp via `world-model setup` but does not additionally register the server in `.mcp.json` will hit the same problem.

Tracked as a v0.12 follow-up: a `world-model doctor` command that detects "hooks wired but no `.mcp.json`" and warns the user. Not part of this PR.

## Files touched

- `.mcp.json` (new)

That's it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)