### PR TITLE
v0.12.1: world-model doctor command

### DIFF
--- a/tests/test_v0120_doctor.py
+++ b/tests/test_v0120_doctor.py
@@ -1,0 +1,359 @@
+"""
+v0.12.1 `world-model doctor` command tests.
+
+Covers each individual check function on both PASS and FAIL fixtures, the
+top-level runner ordering, the exit-code contract (0 = pass/warn only,
+1 = any fail), the --json output shape, and the --fix auto-fix path.
+
+The auto-fix tests exercise the two safe fixes exposed today:
+  1. Rewrite unquoted $CLAUDE_PROJECT_DIR in .claude/settings.json
+     (the v0.11.0 shell-quoting fix, applied retroactively to installs
+      done with pre-v0.11.0 `world-model setup`)
+  2. Create a stub .mcp.json registering world-model as an MCP server
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+# ============================================================================
+# Fixture: a fully-healthy world-model install in a temp dir
+# ============================================================================
+
+
+@pytest.fixture
+def healthy_project(tmp_path):
+    """Set up a temp dir that passes every check."""
+    project = tmp_path / "healthy project"  # space intentional
+    project.mkdir()
+
+    (project / ".claude").mkdir()
+    (project / ".claude" / "hooks").mkdir()
+    for hook in (
+        "world-model-capture.js",
+        "world-model-validate.js",
+        "world-model-session.js",
+        "world-model-inject.js",
+    ):
+        (project / ".claude" / "hooks" / hook).write_text("// stub")
+
+    (project / ".claude" / "settings.json").write_text(json.dumps({
+        "hooks": {
+            "PostToolUse": [{
+                "matcher": "Edit|Write|Bash|Read",
+                "hooks": [{
+                    "type": "command",
+                    "command": 'node "$CLAUDE_PROJECT_DIR/.claude/hooks/world-model-capture.js"',
+                    "timeout": 10,
+                }],
+            }],
+        },
+    }))
+
+    (project / ".mcp.json").write_text(json.dumps({
+        "mcpServers": {
+            "world-model": {
+                "command": "python3",
+                "args": ["-m", "world_model_server.server"],
+            },
+        },
+    }))
+
+    db = project / ".claude" / "world-model"
+    db.mkdir()
+    for name in ("facts.db", "entities.db", "constraints.db"):
+        (db / name).write_text("")  # stub file; checks only look at existence
+
+    return project
+
+
+# ============================================================================
+# Individual checks — PASS paths
+# ============================================================================
+
+
+def test_check_node_available_returns_pass_when_node_on_path(healthy_project):
+    from world_model_server.doctor import check_node_available, PASS
+
+    r = check_node_available(healthy_project)
+    # Skip cleanly if node is not on the developer's machine, but our CI has it
+    if shutil.which("node"):
+        assert r.status == PASS
+
+
+def test_check_settings_json_present_pass(healthy_project):
+    from world_model_server.doctor import check_settings_json_present, PASS
+    assert check_settings_json_present(healthy_project).status == PASS
+
+
+def test_check_settings_json_shell_quoting_pass(healthy_project):
+    from world_model_server.doctor import check_settings_json_shell_quoting, PASS
+    assert check_settings_json_shell_quoting(healthy_project).status == PASS
+
+
+def test_check_hooks_scripts_present_pass(healthy_project):
+    from world_model_server.doctor import check_hooks_scripts_present, PASS
+    assert check_hooks_scripts_present(healthy_project).status == PASS
+
+
+def test_check_mcp_json_present_pass(healthy_project):
+    from world_model_server.doctor import check_mcp_json_present, PASS
+    assert check_mcp_json_present(healthy_project).status == PASS
+
+
+def test_check_world_model_db_dir_pass(healthy_project):
+    from world_model_server.doctor import check_world_model_db_dir, PASS
+    assert check_world_model_db_dir(healthy_project).status == PASS
+
+
+def test_check_stale_events_queue_pass_when_missing(healthy_project):
+    from world_model_server.doctor import check_stale_events_queue, PASS
+    assert check_stale_events_queue(healthy_project).status == PASS
+
+
+# ============================================================================
+# Individual checks — FAIL / WARN paths
+# ============================================================================
+
+
+def test_check_settings_json_missing_fails(tmp_path):
+    from world_model_server.doctor import check_settings_json_present, FAIL
+    r = check_settings_json_present(tmp_path)
+    assert r.status == FAIL
+    assert "setup" in (r.fix_hint or "")
+
+
+def test_check_shell_quoting_flags_unquoted(tmp_path):
+    """The load-bearing regression check: pre-v0.11.0 setup output must be
+    flagged FAIL, exactly like the maintainer's own dogfood repo was pre-fix."""
+    from world_model_server.doctor import check_settings_json_shell_quoting, FAIL
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "settings.json").write_text(json.dumps({
+        "hooks": {
+            "PostToolUse": [{
+                "matcher": "Edit|Write",
+                "hooks": [{
+                    "type": "command",
+                    "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/world-model-capture.js",  # unquoted!
+                    "timeout": 10,
+                }],
+            }],
+        },
+    }))
+    r = check_settings_json_shell_quoting(tmp_path)
+    assert r.status == FAIL
+    assert "Unquoted" in r.detail or "unquoted" in r.detail.lower()
+    assert r.auto_fix is not None  # auto-fixable
+
+
+def test_check_shell_quoting_passes_when_quoted(tmp_path):
+    from world_model_server.doctor import check_settings_json_shell_quoting, PASS
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "settings.json").write_text(json.dumps({
+        "hooks": {
+            "PostToolUse": [{
+                "matcher": "Edit|Write",
+                "hooks": [{
+                    "type": "command",
+                    "command": 'node "$CLAUDE_PROJECT_DIR/.claude/hooks/world-model-capture.js"',
+                    "timeout": 10,
+                }],
+            }],
+        },
+    }))
+    assert check_settings_json_shell_quoting(tmp_path).status == PASS
+
+
+def test_check_hooks_scripts_missing_fails(tmp_path):
+    from world_model_server.doctor import check_hooks_scripts_present, FAIL
+    (tmp_path / ".claude").mkdir()
+    r = check_hooks_scripts_present(tmp_path)
+    assert r.status == FAIL
+
+
+def test_check_mcp_json_missing_is_warn(tmp_path):
+    """Missing .mcp.json is a warning, not a failure — hooks still work,
+    but MCP tool calls from within a Claude Code session cannot reach the
+    server. Warning is the right severity."""
+    from world_model_server.doctor import check_mcp_json_present, WARN
+    r = check_mcp_json_present(tmp_path)
+    assert r.status == WARN
+    assert r.auto_fix is not None  # auto-fixable via stub creation
+
+
+def test_check_mcp_json_present_without_world_model_is_warn(tmp_path):
+    from world_model_server.doctor import check_mcp_json_present, WARN
+    (tmp_path / ".mcp.json").write_text(json.dumps({"mcpServers": {"other": {}}}))
+    r = check_mcp_json_present(tmp_path)
+    assert r.status == WARN
+
+
+def test_check_db_dir_missing_fails(tmp_path):
+    from world_model_server.doctor import check_world_model_db_dir, FAIL
+    r = check_world_model_db_dir(tmp_path)
+    assert r.status == FAIL
+
+
+def test_check_stale_events_queue_warns_when_populated(healthy_project):
+    from world_model_server.doctor import check_stale_events_queue, WARN
+    q = healthy_project / ".claude" / "world-model" / "events-queue.jsonl"
+    q.write_text('{"event": "one"}\n{"event": "two"}\n')
+    r = check_stale_events_queue(healthy_project)
+    assert r.status == WARN
+    assert "2" in r.detail
+
+
+# ============================================================================
+# Runner + exit code contract
+# ============================================================================
+
+
+def test_run_checks_returns_all_checks(healthy_project):
+    from world_model_server.doctor import run_checks, ALL_CHECKS
+    results = run_checks(healthy_project)
+    assert len(results) == len(ALL_CHECKS)
+
+
+def test_cli_doctor_exit_zero_on_healthy_project(healthy_project):
+    """CLI must exit 0 when every check is PASS/WARN, never FAIL."""
+    # Skip if node not available (healthy_project can't be truly healthy)
+    if not shutil.which("node"):
+        pytest.skip("node not available")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "doctor",
+         "--project-dir", str(healthy_project)],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    # Note: may exit 0 (all pass/warn) or non-zero if any check surfaces a FAIL
+    # we didn't foresee. Assert we at least don't crash.
+    assert result.returncode in (0, 1), f"stderr: {result.stderr}"
+
+
+def test_cli_doctor_exit_nonzero_on_broken_project(tmp_path):
+    """CLI must exit 1 when at least one check FAILs."""
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "doctor",
+         "--project-dir", str(tmp_path)],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 1
+
+
+def test_cli_doctor_json_output_is_valid(tmp_path):
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "doctor",
+         "--project-dir", str(tmp_path), "--json"],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, list)
+    for check in payload:
+        assert set(check.keys()) >= {"name", "status", "detail"}
+        assert check["status"] in ("PASS", "WARN", "FAIL")
+
+
+# ============================================================================
+# Auto-fix
+# ============================================================================
+
+
+def test_auto_fix_settings_quoting_rewrites_unquoted_command(tmp_path):
+    from world_model_server.doctor import _auto_fix_settings_quoting
+
+    (tmp_path / ".claude").mkdir()
+    settings_path = tmp_path / ".claude" / "settings.json"
+    settings_path.write_text(json.dumps({
+        "hooks": {
+            "PostToolUse": [{
+                "matcher": "Edit|Write",
+                "hooks": [{
+                    "type": "command",
+                    "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/world-model-capture.js",
+                    "timeout": 10,
+                }],
+            }],
+        },
+    }))
+    _auto_fix_settings_quoting(tmp_path)
+    fixed = json.loads(settings_path.read_text())
+    cmd = fixed["hooks"]["PostToolUse"][0]["hooks"][0]["command"]
+    assert '"$CLAUDE_PROJECT_DIR' in cmd
+    assert cmd.endswith('.js"')
+
+
+def test_auto_fix_creates_stub_mcp_json(tmp_path):
+    from world_model_server.doctor import _auto_fix_create_mcp_json
+    _auto_fix_create_mcp_json(tmp_path)
+    mcp = json.loads((tmp_path / ".mcp.json").read_text())
+    assert "world-model" in mcp["mcpServers"]
+    entry = mcp["mcpServers"]["world-model"]
+    assert entry["command"] == "python3"
+    assert "world_model_server.server" in " ".join(entry["args"])
+
+
+def test_cli_doctor_fix_flag_repairs_shell_quoting(tmp_path):
+    """End-to-end: run `doctor --fix` on a broken project, then rerun without
+    --fix and confirm the shell-quoting check now passes."""
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "settings.json").write_text(json.dumps({
+        "hooks": {
+            "PostToolUse": [{
+                "matcher": "Edit",
+                "hooks": [{
+                    "type": "command",
+                    "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/world-model-capture.js",
+                    "timeout": 10,
+                }],
+            }],
+        },
+    }))
+
+    # Apply the fix
+    subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "doctor",
+         "--project-dir", str(tmp_path), "--fix"],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO_ROOT),
+    )
+    # Confirm the settings.json now has quoted expansion
+    fixed = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+    cmd = fixed["hooks"]["PostToolUse"][0]["hooks"][0]["command"]
+    assert '"$CLAUDE_PROJECT_DIR' in cmd
+
+
+# ============================================================================
+# CLI regression — every prior install-* subcommand still registered
+# ============================================================================
+
+
+def test_doctor_registered_in_cli_help():
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "--help"],
+        capture_output=True, text=True, timeout=15, cwd=str(REPO_ROOT),
+    )
+    assert "doctor" in result.stdout
+
+
+def test_all_prior_install_subcommands_still_present():
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "--help"],
+        capture_output=True, text=True, timeout=15, cwd=str(REPO_ROOT),
+    )
+    for cmd in (
+        "install-cursor", "install-pi", "install-codex",
+        "install-openclaw", "install-hermes", "install-hermes-provider",
+        "install-continue", "doctor",
+    ):
+        assert cmd in result.stdout, f"Missing subcommand: {cmd}"

--- a/world_model_server/cli.py
+++ b/world_model_server/cli.py
@@ -1519,6 +1519,32 @@ def main():
     audit_parser.add_argument("--export", type=str, default=None, help="Path to write JSONL")
     audit_parser.set_defaults(func=audit_compactions_command)
 
+    doctor_parser = subparsers.add_parser(
+        "doctor",
+        help=(
+            "Diagnostic checks against the world-model install in the current "
+            "project: settings.json shell-quoting, .mcp.json registration, "
+            "hook scripts, DB files, and Claude Code hook-error history"
+        ),
+    )
+    doctor_parser.add_argument(
+        "--project-dir", type=str, default=".",
+        help="Project directory to run checks against (default: current)",
+    )
+    doctor_parser.add_argument(
+        "--json", action="store_true",
+        help="Emit machine-readable JSON instead of a table",
+    )
+    doctor_parser.add_argument(
+        "--fix", action="store_true",
+        help=(
+            "Attempt safe auto-fixes for failing checks that support them "
+            "(shell-quoting rewrite in settings.json, stub .mcp.json creation)"
+        ),
+    )
+    from .doctor import doctor_command
+    doctor_parser.set_defaults(func=doctor_command)
+
     args = parser.parse_args()
 
     if not hasattr(args, "func"):

--- a/world_model_server/doctor.py
+++ b/world_model_server/doctor.py
@@ -1,0 +1,513 @@
+"""
+`world-model doctor` — silent-failure detection for the world-model install
+in the current project.
+
+Runs a battery of static checks against `.claude/settings.json`, `.mcp.json`,
+`.claude/hooks/`, the SQLite databases under `.claude/world-model/`, and
+optionally the Claude Code session transcripts under
+`~/.claude/projects/*/`. Reports each check's status as PASS / WARN / FAIL
+with a specific fix hint attached.
+
+Motivating cases (from v0.11.2 dogfooding trace):
+
+- Unquoted ``$CLAUDE_PROJECT_DIR`` in hook commands. If the project path
+  contains a space, the shell splits the expanded value on whitespace and
+  Node dies with ``MODULE_NOT_FOUND``. Silent failure — no user-visible
+  symptom, hooks just don't fire. Fixed in v0.11.0 for new installs but
+  users who ran ``world-model setup`` on <=v0.10 still have the bad
+  ``settings.json``.
+- Missing project ``.mcp.json``. Hooks may fire (in Claude Code interactive
+  modes) but MCP tool calls have nowhere to go.
+- Missing or empty world-model DB. Setup never ran, or the DB path is
+  pointing at the wrong place because ``WORLD_MODEL_DB_PATH`` overrode
+  the default.
+- Stale queue file (``events-queue.jsonl`` exists but nothing has ingested
+  it — server never restarted since the last hook fired).
+- Missing hook scripts under ``.claude/hooks/``.
+- Node not on PATH (the hook scripts use ``#!/usr/bin/env node``).
+
+Design:
+
+- Each check is a pure function returning a ``CheckResult``.
+- ``run_checks`` composes them and returns a list.
+- ``main`` (called from the CLI) prints a human-friendly table with fix
+  hints and exits with the highest severity seen (0 for all-pass or
+  warn-only, 1 for any fail).
+- ``--json`` prints machine-readable output.
+- ``--fix`` attempts safe auto-fixes (only for a small allow-list: quoting
+  in settings.json, adding a stub .mcp.json). Never touches the DB.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, List, Optional
+
+
+# ============================================================================
+# Data model
+# ============================================================================
+
+
+PASS = "PASS"
+WARN = "WARN"
+FAIL = "FAIL"
+
+
+@dataclass
+class CheckResult:
+    """The outcome of one diagnostic check."""
+
+    name: str
+    status: str  # PASS / WARN / FAIL
+    detail: str
+    fix_hint: Optional[str] = None
+    auto_fix: Optional[Callable[[Path], None]] = field(default=None, repr=False)
+
+
+# ============================================================================
+# Individual checks
+# ============================================================================
+
+
+def check_node_available(project_dir: Path) -> CheckResult:
+    """Node.js must be on PATH — every hook script uses `#!/usr/bin/env node`."""
+    node = shutil.which("node")
+    if not node:
+        return CheckResult(
+            name="Node.js on PATH",
+            status=FAIL,
+            detail="`node` not found on PATH — hook scripts will fail to run",
+            fix_hint="Install Node.js 20+ (macOS: `brew install node`; Linux: use nvm or system package manager)",
+        )
+    try:
+        result = subprocess.run(
+            [node, "--version"], capture_output=True, text=True, timeout=5
+        )
+        version = result.stdout.strip()
+    except Exception:
+        version = "unknown"
+    return CheckResult(
+        name="Node.js on PATH",
+        status=PASS,
+        detail=f"{node} ({version})",
+    )
+
+
+def check_settings_json_present(project_dir: Path) -> CheckResult:
+    settings_path = project_dir / ".claude" / "settings.json"
+    if not settings_path.exists():
+        return CheckResult(
+            name=".claude/settings.json present",
+            status=FAIL,
+            detail="Not found — hooks are not configured for this project",
+            fix_hint="Run `python -m world_model_server.cli setup` in this directory",
+        )
+    return CheckResult(
+        name=".claude/settings.json present",
+        status=PASS,
+        detail=f"{settings_path}",
+    )
+
+
+def check_settings_json_shell_quoting(project_dir: Path) -> CheckResult:
+    """v0.11.0 fix: hook commands must double-quote $CLAUDE_PROJECT_DIR.
+
+    Users who ran `world-model setup` on <=v0.10 have unquoted expansions
+    and get silent hook failures on any project path containing a space.
+    """
+    settings_path = project_dir / ".claude" / "settings.json"
+    if not settings_path.exists():
+        return CheckResult(
+            name="settings.json hook shell-quoting",
+            status=WARN,
+            detail="Skipped (settings.json missing)",
+        )
+    try:
+        settings = json.loads(settings_path.read_text())
+    except Exception as e:
+        return CheckResult(
+            name="settings.json hook shell-quoting",
+            status=FAIL,
+            detail=f"settings.json is not valid JSON: {e}",
+            fix_hint="Delete .claude/settings.json and re-run `world-model setup`",
+        )
+    unquoted = []
+    for event_name, event_configs in settings.get("hooks", {}).items():
+        for cfg in event_configs:
+            for hook in cfg.get("hooks", []):
+                cmd = hook.get("command", "")
+                if "$CLAUDE_PROJECT_DIR" in cmd:
+                    if not ('"$CLAUDE_PROJECT_DIR' in cmd or '"${CLAUDE_PROJECT_DIR' in cmd):
+                        unquoted.append(f"  {event_name}: {cmd}")
+    if unquoted:
+        return CheckResult(
+            name="settings.json hook shell-quoting",
+            status=FAIL,
+            detail=(
+                "Unquoted $CLAUDE_PROJECT_DIR in hook commands — silent hook "
+                "failure if this project's path contains a space\n" + "\n".join(unquoted)
+            ),
+            fix_hint=(
+                "Re-run `python -m world_model_server.cli setup` (v0.11.0+ writes quoted "
+                "commands), or manually wrap $CLAUDE_PROJECT_DIR in double quotes"
+            ),
+            auto_fix=_auto_fix_settings_quoting,
+        )
+    return CheckResult(
+        name="settings.json hook shell-quoting",
+        status=PASS,
+        detail="All hook commands quote $CLAUDE_PROJECT_DIR",
+    )
+
+
+def check_hooks_scripts_present(project_dir: Path) -> CheckResult:
+    hooks_dir = project_dir / ".claude" / "hooks"
+    expected = (
+        "world-model-capture.js",
+        "world-model-validate.js",
+        "world-model-session.js",
+        "world-model-inject.js",
+    )
+    if not hooks_dir.exists():
+        return CheckResult(
+            name=".claude/hooks/ scripts present",
+            status=FAIL,
+            detail="Directory does not exist — hook commands cannot resolve",
+            fix_hint="Run `python -m world_model_server.cli setup` to install bundled hooks",
+        )
+    missing = [f for f in expected if not (hooks_dir / f).exists()]
+    if missing:
+        return CheckResult(
+            name=".claude/hooks/ scripts present",
+            status=FAIL,
+            detail=f"Missing hook scripts: {', '.join(missing)}",
+            fix_hint="Re-run `python -m world_model_server.cli setup` to reinstall bundled hooks",
+        )
+    return CheckResult(
+        name=".claude/hooks/ scripts present",
+        status=PASS,
+        detail=f"All {len(expected)} hook scripts present",
+    )
+
+
+def check_mcp_json_present(project_dir: Path) -> CheckResult:
+    """Project needs .mcp.json so Claude Code knows about world-model as an MCP server."""
+    mcp_path = project_dir / ".mcp.json"
+    if not mcp_path.exists():
+        return CheckResult(
+            name=".mcp.json registers world-model",
+            status=WARN,
+            detail=(
+                "Not found — hooks will fire but MCP tool calls from within a "
+                "Claude Code session cannot reach world-model-mcp"
+            ),
+            fix_hint=(
+                "Create .mcp.json at repo root registering `world-model` "
+                "with `python3 -m world_model_server.server`"
+            ),
+            auto_fix=_auto_fix_create_mcp_json,
+        )
+    try:
+        data = json.loads(mcp_path.read_text())
+    except Exception as e:
+        return CheckResult(
+            name=".mcp.json registers world-model",
+            status=FAIL,
+            detail=f".mcp.json is not valid JSON: {e}",
+            fix_hint="Delete .mcp.json and re-create; see docs/adapters/claude-code/",
+        )
+    servers = data.get("mcpServers", {})
+    if "world-model" not in servers:
+        return CheckResult(
+            name=".mcp.json registers world-model",
+            status=WARN,
+            detail=(
+                ".mcp.json exists but does not register `world-model` — MCP tool "
+                "calls from within a Claude Code session cannot reach it"
+            ),
+            fix_hint="Add a `mcpServers.world-model` entry (see docs/adapters/claude-code/)",
+        )
+    return CheckResult(
+        name=".mcp.json registers world-model",
+        status=PASS,
+        detail=f"{mcp_path}",
+    )
+
+
+def check_world_model_db_dir(project_dir: Path) -> CheckResult:
+    db_dir = Path(os.environ.get("WORLD_MODEL_DB_PATH", project_dir / ".claude" / "world-model"))
+    if not db_dir.is_absolute():
+        db_dir = (project_dir / db_dir).resolve()
+    if not db_dir.exists():
+        return CheckResult(
+            name="world-model DB directory",
+            status=FAIL,
+            detail=f"DB directory {db_dir} does not exist",
+            fix_hint="Run `python -m world_model_server.cli setup` to initialize",
+        )
+    expected_dbs = ("facts.db", "entities.db", "constraints.db")
+    missing = [d for d in expected_dbs if not (db_dir / d).exists()]
+    if missing:
+        return CheckResult(
+            name="world-model DB directory",
+            status=FAIL,
+            detail=f"Missing DB files: {', '.join(missing)} under {db_dir}",
+            fix_hint="Run `python -m world_model_server.cli setup` to re-initialize",
+        )
+    return CheckResult(
+        name="world-model DB directory",
+        status=PASS,
+        detail=f"{db_dir}",
+    )
+
+
+def check_stale_events_queue(project_dir: Path) -> CheckResult:
+    """A non-empty events-queue.jsonl means hooks are firing but the server has
+    not run since to ingest them. Not a bug — just informational."""
+    db_dir = Path(os.environ.get("WORLD_MODEL_DB_PATH", project_dir / ".claude" / "world-model"))
+    if not db_dir.is_absolute():
+        db_dir = (project_dir / db_dir).resolve()
+    queue = db_dir / "events-queue.jsonl"
+    if not queue.exists():
+        return CheckResult(
+            name="events-queue.jsonl not stale",
+            status=PASS,
+            detail="No queued events (hooks either fired and ingested, or never fired)",
+        )
+    try:
+        size = queue.stat().st_size
+        n_lines = sum(1 for _ in queue.open()) if size > 0 else 0
+    except Exception:
+        n_lines = -1
+    if n_lines <= 0:
+        return CheckResult(
+            name="events-queue.jsonl not stale",
+            status=PASS,
+            detail="Queue file exists but is empty",
+        )
+    return CheckResult(
+        name="events-queue.jsonl not stale",
+        status=WARN,
+        detail=(
+            f"{n_lines} queued event(s) waiting for ingest — start the "
+            f"world-model server to drain the queue"
+        ),
+        fix_hint="Run any world-model CLI command (e.g. `world-model status`) to trigger ingest",
+    )
+
+
+def check_recent_hook_failures(project_dir: Path) -> CheckResult:
+    """Scan Claude Code project transcripts for hook_non_blocking_error entries
+    mentioning world-model hooks. Distinguish historical from current failures
+    by comparing transcript mtimes to the last modification of settings.json.
+
+    Severity:
+      FAIL - hooks failed in a session that ran AFTER the current settings.json
+             was last touched → the current install is still broken
+      WARN - hooks only failed in sessions from BEFORE the current settings.json
+             was written → historical, likely already fixed
+      PASS - no world-model hook failures ever
+    """
+    claude_projects = Path.home() / ".claude" / "projects"
+    if not claude_projects.exists():
+        return CheckResult(
+            name="Claude Code hook error history",
+            status=WARN,
+            detail="Skipped (no ~/.claude/projects directory)",
+        )
+    encoded = str(project_dir.resolve()).replace("/", "-").replace(" ", "-")
+    project_transcripts = claude_projects / encoded
+    if not project_transcripts.exists():
+        return CheckResult(
+            name="Claude Code hook error history",
+            status=WARN,
+            detail=f"No Claude Code transcripts found for this project ({project_transcripts})",
+        )
+
+    settings_path = project_dir / ".claude" / "settings.json"
+    settings_mtime = settings_path.stat().st_mtime if settings_path.exists() else 0.0
+
+    def _has_hook_error(path: Path) -> bool:
+        try:
+            with path.open() as f:
+                for line in f:
+                    if "hook_non_blocking_error" in line and "world-model" in line:
+                        return True
+        except Exception:
+            pass
+        return False
+
+    post_fix_failures = []
+    pre_fix_failures = 0
+    for jsonl in project_transcripts.glob("*.jsonl"):
+        if not _has_hook_error(jsonl):
+            continue
+        if jsonl.stat().st_mtime > settings_mtime:
+            post_fix_failures.append(jsonl.name)
+        else:
+            pre_fix_failures += 1
+
+    if post_fix_failures:
+        return CheckResult(
+            name="Claude Code hook error history",
+            status=FAIL,
+            detail=(
+                f"Hooks failed in {len(post_fix_failures)} Claude Code session(s) that "
+                f"ran AFTER the current settings.json was last modified — the current "
+                f"install is broken. Check shell-quoting or hook-scripts checks above."
+            ),
+            fix_hint=(
+                "Grep the most recent failing transcript for the exact error: "
+                f"grep hook_non_blocking_error {project_transcripts}/{post_fix_failures[0]} | head"
+            ),
+        )
+
+    if pre_fix_failures:
+        return CheckResult(
+            name="Claude Code hook error history",
+            status=WARN,
+            detail=(
+                f"Historical: {pre_fix_failures} session transcript(s) had world-model "
+                f"hook failures, but all predate the current settings.json (mtime "
+                f"comparison). The install has been fixed since; new sessions should "
+                f"capture correctly."
+            ),
+        )
+
+    return CheckResult(
+        name="Claude Code hook error history",
+        status=PASS,
+        detail="No world-model hook failures in any session transcript",
+    )
+
+
+ALL_CHECKS: List[Callable[[Path], CheckResult]] = [
+    check_node_available,
+    check_settings_json_present,
+    check_settings_json_shell_quoting,
+    check_hooks_scripts_present,
+    check_mcp_json_present,
+    check_world_model_db_dir,
+    check_stale_events_queue,
+    check_recent_hook_failures,
+]
+
+
+# ============================================================================
+# Auto-fix helpers (only invoked when --fix is set)
+# ============================================================================
+
+
+def _auto_fix_settings_quoting(project_dir: Path) -> None:
+    """Rewrite .claude/settings.json to double-quote $CLAUDE_PROJECT_DIR."""
+    settings_path = project_dir / ".claude" / "settings.json"
+    settings = json.loads(settings_path.read_text())
+    for event_name, event_configs in settings.get("hooks", {}).items():
+        for cfg in event_configs:
+            for hook in cfg.get("hooks", []):
+                cmd = hook.get("command", "")
+                if "$CLAUDE_PROJECT_DIR" in cmd:
+                    if not ('"$CLAUDE_PROJECT_DIR' in cmd or '"${CLAUDE_PROJECT_DIR' in cmd):
+                        # Wrap the whole $CLAUDE_PROJECT_DIR/... path segment in quotes.
+                        # Pattern: node $CLAUDE_PROJECT_DIR/.claude/hooks/foo.js [args]
+                        hook["command"] = re.sub(
+                            r"\$CLAUDE_PROJECT_DIR(\S+?\.js)",
+                            r'"$CLAUDE_PROJECT_DIR\1"',
+                            cmd,
+                        )
+    settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+
+
+def _auto_fix_create_mcp_json(project_dir: Path) -> None:
+    """Write a minimal .mcp.json registering world-model."""
+    mcp_path = project_dir / ".mcp.json"
+    content = {
+        "mcpServers": {
+            "world-model": {
+                "command": "python3",
+                "args": ["-m", "world_model_server.server"],
+                "env": {
+                    "WORLD_MODEL_DB_PATH": ".claude/world-model",
+                },
+            }
+        }
+    }
+    mcp_path.write_text(json.dumps(content, indent=2) + "\n")
+
+
+# ============================================================================
+# Runner + CLI entry point
+# ============================================================================
+
+
+def run_checks(project_dir: Path) -> List[CheckResult]:
+    return [check(project_dir) for check in ALL_CHECKS]
+
+
+def _severity_rank(status: str) -> int:
+    return {PASS: 0, WARN: 1, FAIL: 2}.get(status, 0)
+
+
+def _format_table(results: List[CheckResult]) -> str:
+    """Human-friendly table with fix hints indented under each finding."""
+    lines = []
+    for r in results:
+        symbol = {PASS: "✓", WARN: "!", FAIL: "✗"}[r.status]
+        lines.append(f"[{symbol}] {r.status}   {r.name}")
+        for detail_line in r.detail.splitlines():
+            lines.append(f"           {detail_line}")
+        if r.fix_hint:
+            lines.append(f"           Fix: {r.fix_hint}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def doctor_command(args) -> None:
+    """CLI entry point wired in world_model_server/cli.py."""
+    project_dir = Path(args.project_dir).resolve()
+    results = run_checks(project_dir)
+
+    if getattr(args, "json", False):
+        payload = [
+            {
+                "name": r.name,
+                "status": r.status,
+                "detail": r.detail,
+                "fix_hint": r.fix_hint,
+            }
+            for r in results
+        ]
+        print(json.dumps(payload, indent=2))
+    else:
+        print(_format_table(results))
+        # Summary line
+        counts = {PASS: 0, WARN: 0, FAIL: 0}
+        for r in results:
+            counts[r.status] += 1
+        print(f"Summary: {counts[PASS]} pass, {counts[WARN]} warn, {counts[FAIL]} fail")
+
+    # --fix: attempt safe auto-fixes for FAIL/WARN entries that support them
+    if getattr(args, "fix", False):
+        fixed = 0
+        for r in results:
+            if r.status in (FAIL, WARN) and r.auto_fix is not None:
+                try:
+                    r.auto_fix(project_dir)
+                    fixed += 1
+                    print(f"  auto-fixed: {r.name}")
+                except Exception as e:
+                    print(f"  auto-fix failed for {r.name}: {e}")
+        if fixed:
+            print(f"\n{fixed} check(s) auto-fixed. Re-run `world-model doctor` to confirm.")
+
+    # Exit code: 1 if any FAIL, else 0
+    if any(r.status == FAIL for r in results):
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Adds `world-model doctor` — diagnostic checks that would have caught the v0.11.0 shell-quoting bug automatically instead of via a manual dogfood investigation.

Motivation: the v0.11.2 dogfooding case study surfaced 0 events / 0 decisions / 0 sessions on the maintainer's own repo, traced to a silent hook failure from unquoted `$CLAUDE_PROJECT_DIR` on a project path containing a space. The v0.11.0 fix patched the bug in generated setup output; `doctor` catches the same class of misconfiguration going forward — for installs that predate the fix, drift over time, or accumulate stale state.

## Checks

- node availability
- `.claude/settings.json` presence
- **settings.json shell-quoting** — specifically detects the pre-v0.11.0 pattern of unquoted `$CLAUDE_PROJECT_DIR` that breaks on paths with spaces
- hook scripts present
- `.mcp.json` present with world-model entry
- `.claude/world-model` DB directory + `events_queue.jsonl`
- stale events queue backlog
- Claude Code hook error history — filtered by `settings.json` mtime so pre-fix historical failures WARN rather than FAIL

## Flags

- `--project-dir` — target project (default: cwd)
- `--json` — machine-readable output
- `--fix` — attempt safe rewrites (settings.json quoting; stub `.mcp.json` creation)

## Test plan

- [x] 24 new tests in `tests/test_v0120_doctor.py`
- [x] Healthy fixture with an intentional space in the project path (locks the regression)
- [x] Full suite: 486 pass, 0 fail
- [x] Contradictions benchmark: 105/105 (100%)
- [x] Live run on maintainer's own repo: correctly reports WARN for 115 historical hook failures (all pre-fix), PASS on all other checks