### PR TITLE
v0.12.3: universal content-type routing consumers

### DIFF
--- a/tests/test_v0123_content_type_routing.py
+++ b/tests/test_v0123_content_type_routing.py
@@ -1,0 +1,326 @@
+"""
+v0.12.3: universal content-type routing consumers.
+
+The v0.11.1 patch added a nullable content_type field on Fact + facts
+table but did not wire any consumer. Worse, create_fact did not persist
+the field — a value set on the Fact model was silently dropped by the
+INSERT. This suite covers:
+
+  W1 create_fact now persists content_type (plus the v0.12.2 governance
+     fields, which had the same gap).
+  R1 query_facts + tools.query_fact accept a content_type filter and
+     return only rows with that type. NULL rows are excluded when the
+     filter is set.
+  I1 get_injection_context splits its bundle into a dedicated Rules
+     section (drawn first) and a Recent facts section (fills remaining
+     slots).
+  I2 Procedures are never auto-injected. They only surface when
+     query_fact is called with content_type='procedure'.
+  I3 The rules/facts budget is respected: max_facts caps the combined
+     total across both sections.
+  B1 Legacy rows (content_type NULL) continue to appear in the Recent
+     facts section — they are treated as 'fact' for auto-inject.
+  S1 MCP query_fact tool schema and Hermes surfaced tool schema both
+     expose the content_type param.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+import pytest
+
+from world_model_server.config import Config
+from world_model_server.knowledge_graph import KnowledgeGraph
+from world_model_server.models import Fact
+from world_model_server.tools import WorldModelTools
+
+
+# ----------------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def tools(tmp_path):
+    """A tools instance backed by a fresh temp KG."""
+    kg = KnowledgeGraph(str(tmp_path / "wm"))
+    await kg.initialize()
+    config = Config(db_path=str(tmp_path / "wm"))
+    return WorldModelTools(kg, config), kg
+
+
+async def _seed_typed_facts(kg):
+    """Seed one fact of each content_type plus a NULL legacy row."""
+    now = datetime.now()
+    await kg.create_fact(Fact(
+        id="rule-1",
+        fact_text="Always await async database calls",
+        evidence_path="rules/async.md",
+        status="canonical",
+        content_type="rule",
+        valid_at=now,
+    ))
+    await kg.create_fact(Fact(
+        id="fact-1",
+        fact_text="Endpoint POST /users returns 201 on success",
+        evidence_path="src/api/users.ts:42",
+        status="canonical",
+        content_type="fact",
+        valid_at=now,
+    ))
+    await kg.create_fact(Fact(
+        id="proc-1",
+        fact_text="Deploy runbook: bump version, tag, push, gh release",
+        evidence_path="docs/deploy.md",
+        status="canonical",
+        content_type="procedure",
+        valid_at=now,
+    ))
+    await kg.create_fact(Fact(
+        id="legacy-1",
+        fact_text="Legacy row with no content_type",
+        evidence_path="legacy/x.py",
+        status="canonical",
+        content_type=None,
+        valid_at=now,
+    ))
+
+
+# ----------------------------------------------------------------------------
+# W1: create_fact persists content_type + governance fields
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_w1_create_fact_persists_content_type(tools):
+    """The load-bearing regression: prior to v0.12.3, create_fact silently
+    dropped content_type. This must never happen again."""
+    _, kg = tools
+    await kg.create_fact(Fact(
+        id="rule-persist",
+        fact_text="A rule",
+        evidence_path="p",
+        content_type="rule",
+    ))
+    row = await kg.get_fact_by_id("rule-persist")
+    assert row is not None
+    assert row.get("content_type") == "rule"
+
+
+@pytest.mark.asyncio
+async def test_w1_create_fact_persists_influence_state(tools):
+    _, kg = tools
+    await kg.create_fact(Fact(
+        id="obs-1",
+        fact_text="Observed but not yet trusted",
+        evidence_path="p",
+        influence_state="observed",
+    ))
+    row = await kg.get_fact_by_id("obs-1")
+    assert row.get("influence_state") == "observed"
+
+
+@pytest.mark.asyncio
+async def test_w1_create_fact_persists_expires_at(tools):
+    _, kg = tools
+    expiry = datetime(2027, 1, 1, 12, 0, 0)
+    await kg.create_fact(Fact(
+        id="exp-1",
+        fact_text="Expires 2027",
+        evidence_path="p",
+        expires_at=expiry,
+    ))
+    row = await kg.get_fact_by_id("exp-1")
+    # Stored as ISO string; compare on parse
+    assert row.get("expires_at") is not None
+    assert datetime.fromisoformat(row["expires_at"]) == expiry
+
+
+@pytest.mark.asyncio
+async def test_w1_create_fact_null_defaults_preserved(tools):
+    """A fact without any of the new fields set writes NULL for all three."""
+    _, kg = tools
+    await kg.create_fact(Fact(
+        id="plain-1",
+        fact_text="Plain fact, no new fields",
+        evidence_path="p",
+    ))
+    row = await kg.get_fact_by_id("plain-1")
+    assert row.get("content_type") is None
+    assert row.get("influence_state") is None
+    assert row.get("expires_at") is None
+
+
+# ----------------------------------------------------------------------------
+# R1: content_type filter on query
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_r1_query_facts_filters_by_content_type(tools):
+    _, kg = tools
+    await _seed_typed_facts(kg)
+
+    rule_hits = await kg.query_facts(query="async", content_type="rule")
+    assert len(rule_hits.facts) == 1
+    assert rule_hits.facts[0].id == "rule-1"
+
+    # A term that would match the fact but not the rule
+    fact_hits = await kg.query_facts(query="Endpoint", content_type="fact")
+    assert len(fact_hits.facts) == 1
+    assert fact_hits.facts[0].id == "fact-1"
+
+
+@pytest.mark.asyncio
+async def test_r1_query_facts_content_type_excludes_null(tools):
+    _, kg = tools
+    await _seed_typed_facts(kg)
+    # Search a term that matches the legacy NULL row; a typed filter must
+    # exclude it (NULL cannot answer a typed query).
+    hits = await kg.query_facts(query="Legacy", content_type="rule")
+    assert len(hits.facts) == 0
+
+
+@pytest.mark.asyncio
+async def test_r1_query_facts_no_content_type_includes_everything(tools):
+    _, kg = tools
+    await _seed_typed_facts(kg)
+    # With no content_type filter, a search that matches multiple types
+    # must return all of them (backward-compat).
+    hits = await kg.query_facts(query="Legacy OR async OR Endpoint OR Deploy")
+    ids = {f.id for f in hits.facts}
+    assert {"rule-1", "fact-1", "proc-1", "legacy-1"}.issubset(ids)
+
+
+@pytest.mark.asyncio
+async def test_r1_tools_query_fact_passes_content_type_through(tools):
+    t, kg = tools
+    await _seed_typed_facts(kg)
+    result = await t.query_fact(query="Deploy", content_type="procedure")
+    assert len(result.facts) == 1
+    assert result.facts[0].id == "proc-1"
+
+
+@pytest.mark.asyncio
+async def test_r1_query_facts_hydrates_content_type_field(tools):
+    _, kg = tools
+    await _seed_typed_facts(kg)
+    hits = await kg.query_facts(query="async")
+    assert hits.facts
+    assert hits.facts[0].content_type == "rule"
+
+
+# ----------------------------------------------------------------------------
+# I1: get_injection_context routes rules into a dedicated section
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_i1_injection_context_contains_rules_section(tools):
+    t, kg = tools
+    await _seed_typed_facts(kg)
+    payload = json.loads(await t.get_injection_context(event_type="PostCompact"))
+    assert "## Rules (always active)" in payload["injection"]
+    assert "Always await async database calls" in payload["injection"]
+    assert payload["rules_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_i1_injection_context_reports_fact_and_rule_counts_separately(tools):
+    t, kg = tools
+    await _seed_typed_facts(kg)
+    payload = json.loads(await t.get_injection_context(event_type="PostCompact"))
+    assert payload["rules_count"] == 1
+    # fact-1 and legacy-1 both count as fact-pool for auto-inject; proc-1 does not.
+    assert payload["facts_count"] == 2
+
+
+# ----------------------------------------------------------------------------
+# I2: procedures are never auto-injected
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_i2_procedure_excluded_from_injection(tools):
+    t, kg = tools
+    await _seed_typed_facts(kg)
+    payload = json.loads(await t.get_injection_context(event_type="PostCompact"))
+    assert "Deploy runbook" not in payload["injection"]
+
+
+@pytest.mark.asyncio
+async def test_i2_procedure_reachable_via_explicit_query(tools):
+    t, kg = tools
+    await _seed_typed_facts(kg)
+    result = await t.query_fact(query="Deploy", content_type="procedure")
+    assert len(result.facts) == 1
+    assert result.facts[0].id == "proc-1"
+
+
+# ----------------------------------------------------------------------------
+# I3: rules-first budget
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_i3_rules_get_first_shot_at_max_facts_budget(tools):
+    """When max_facts=1, and both a rule and a fact match, the rule is
+    picked over the fact."""
+    t, kg = tools
+    await _seed_typed_facts(kg)
+    payload = json.loads(await t.get_injection_context(
+        event_type="PostCompact",
+        max_facts=1,
+    ))
+    assert payload["rules_count"] == 1
+    assert payload["facts_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_i3_combined_budget_respected(tools):
+    """max_facts=2 with 1 rule + 2 fact-pool rows: 1 rule + 1 fact = 2 total."""
+    t, kg = tools
+    await _seed_typed_facts(kg)
+    payload = json.loads(await t.get_injection_context(
+        event_type="PostCompact",
+        max_facts=2,
+    ))
+    assert payload["rules_count"] + payload["facts_count"] == 2
+    assert payload["rules_count"] == 1
+
+
+# ----------------------------------------------------------------------------
+# B1: legacy NULL rows behave as 'fact' for injection routing
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_b1_null_content_type_row_appears_in_facts_section(tools):
+    t, kg = tools
+    await _seed_typed_facts(kg)
+    payload = json.loads(await t.get_injection_context(event_type="PostCompact"))
+    assert "Legacy row with no content_type" in payload["injection"]
+
+
+# ----------------------------------------------------------------------------
+# S1: schema surfaces expose content_type
+# ----------------------------------------------------------------------------
+
+
+def test_s1_hermes_surfaced_query_fact_schema_exposes_content_type():
+    from world_model_server.hermes_memory_provider import _surfaced_tool_schemas
+    schemas = list(_surfaced_tool_schemas())
+    qf = next(s for s in schemas if s["name"] == "query_fact")
+    props = qf["inputSchema"]["properties"]
+    assert "content_type" in props
+    assert set(props["content_type"]["enum"]) == {"rule", "fact", "procedure"}
+
+
+def test_s1_hermes_surfaced_query_fact_schema_still_requires_only_query():
+    """Adding an optional field must not silently change the required list."""
+    from world_model_server.hermes_memory_provider import _surfaced_tool_schemas
+    schemas = list(_surfaced_tool_schemas())
+    qf = next(s for s in schemas if s["name"] == "query_fact")
+    assert qf["inputSchema"]["required"] == ["query"]

--- a/world_model_server/hermes_memory_provider/README.md
+++ b/world_model_server/hermes_memory_provider/README.md
@@ -89,6 +89,29 @@ state files at `<hermes_home>/`. To share the fact graph with a
 project-scoped Claude Code / Cursor install, set
 `WORLD_MODEL_DB_PATH` before starting Hermes.
 
+## Content-type routing (v0.12.3)
+
+Every fact carries an optional `content_type` field: `rule`, `fact`,
+or `procedure`. When `get_injection_context` runs at PostCompact,
+UserPromptSubmit, or SessionStart, it routes by that field:
+
+| content_type | Auto-inject at boundary? | How to retrieve |
+| --- | --- | --- |
+| `rule` | **Yes** — dedicated "Rules (always active)" section, drawn first from the fact budget | Also queryable via `query_fact` with `content_type='rule'` |
+| `fact` (or NULL) | Yes, but only in the remaining fact budget after rules are placed | Default target of `query_fact` |
+| `procedure` | **No** — never auto-injected | Only surfaced when explicitly summoned via `query_fact` with `content_type='procedure'` |
+
+The rationale: on a Hermes agent turn the LLM should see cross-cutting
+rules unconditionally, look up facts as needed, and pull procedures
+only when a workflow is actually being executed. Silent injection of
+long procedures at every boundary wastes context; silent injection of
+rules is precisely what rules are for.
+
+`content_type` is nullable and legacy rows without the field are
+treated as `fact` for routing purposes (they compete for the same
+fact-budget slots). Writes are set at insert time by the caller — the
+plugin does not infer content_type from fact text.
+
 ## Caveats
 
 - **Sync ↔ async bridge.** Hermes' ABC is synchronous;

--- a/world_model_server/hermes_memory_provider/__init__.py
+++ b/world_model_server/hermes_memory_provider/__init__.py
@@ -226,7 +226,12 @@ def _surfaced_tool_schemas():
     """
     yield {
         "name": "query_fact",
-        "description": "Query the world-model knowledge graph for facts about entities (APIs, functions, classes, constraints).",
+        "description": (
+            "Query the world-model knowledge graph for facts about entities "
+            "(APIs, functions, classes, constraints). Pass content_type='procedure' "
+            "to explicitly summon procedures, which are excluded from auto-injection "
+            "by design (v0.12.3 content-type routing)."
+        ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -236,6 +241,10 @@ def _surfaced_tool_schemas():
                     "enum": ["api", "function", "class", "constraint", "file", "package"],
                 },
                 "context": {"type": "object"},
+                "content_type": {
+                    "type": "string",
+                    "enum": ["rule", "fact", "procedure"],
+                },
             },
             "required": ["query"],
         },

--- a/world_model_server/knowledge_graph.py
+++ b/world_model_server/knowledge_graph.py
@@ -621,15 +621,23 @@ class KnowledgeGraph:
     # ============================================================================
 
     async def create_fact(self, fact: Fact) -> str:
-        """Create a new fact."""
+        """Create a new fact.
+
+        v0.12.3 extends the INSERT to persist content_type (added in v0.11.1)
+        plus the v0.12.2 governance fields (influence_state, expires_at).
+        Prior to v0.12.3 these fields lived on the Fact model but never
+        reached the DB, so callers that set them saw the value silently
+        dropped. All three are nullable and existing callers are unaffected.
+        """
         async with aiosqlite.connect(self.facts_db) as db:
             await db.execute(
                 """
                 INSERT INTO facts
                 (id, fact_text, valid_at, invalid_at, status, entity_ids, evidence_type,
                  evidence_path, derived_from, confidence, session_id, created_at,
-                 source_count, last_confirmed_at, source_tool, confirmer)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 source_count, last_confirmed_at, source_tool, confirmer,
+                 content_type, influence_state, expires_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 (
                     fact.id,
@@ -648,6 +656,9 @@ class KnowledgeGraph:
                     fact.last_confirmed_at.isoformat() if fact.last_confirmed_at else None,
                     fact.source_tool,
                     fact.confirmer,
+                    fact.content_type,
+                    fact.influence_state,
+                    fact.expires_at.isoformat() if fact.expires_at else None,
                 ),
             )
             await db.commit()
@@ -659,6 +670,7 @@ class KnowledgeGraph:
         query: str,
         entity_type: Optional[str] = None,
         current_only: bool = True,
+        content_type: Optional[str] = None,
     ) -> QueryFactResult:
         """
         Query facts using full-text search. Results are cached for performance.
@@ -667,11 +679,14 @@ class KnowledgeGraph:
             query: Search query
             entity_type: Filter by entity type
             current_only: Only return facts where invalid_at IS NULL
+            content_type: Optional filter by content_type ('rule' / 'fact' /
+                'procedure'). NULL rows are always excluded when this is set
+                — a NULL row is unclassified and cannot answer a typed query.
 
         Returns:
             QueryFactResult with matching facts and confidence
         """
-        cache_key = f"facts:{query}:{entity_type}:{current_only}"
+        cache_key = f"facts:{query}:{entity_type}:{current_only}:{content_type}"
         cached = self._cache_get(cache_key)
         if cached is not None:
             return cached
@@ -689,6 +704,10 @@ class KnowledgeGraph:
 
             if current_only:
                 sql_query += " AND f.invalid_at IS NULL"
+
+            if content_type is not None:
+                sql_query += " AND f.content_type = ?"
+                params.append(content_type)
 
             sql_query += " ORDER BY f.confidence DESC, f.created_at DESC LIMIT 10"
 
@@ -733,6 +752,13 @@ class KnowledgeGraph:
                         created_at=datetime.fromisoformat(decayed["created_at"]),
                         source_tool=decayed.get("source_tool"),
                         confirmer=decayed.get("confirmer"),
+                        content_type=decayed.get("content_type"),
+                        influence_state=decayed.get("influence_state"),
+                        expires_at=(
+                            datetime.fromisoformat(decayed["expires_at"])
+                            if decayed.get("expires_at")
+                            else None
+                        ),
                     )
                 )
 

--- a/world_model_server/server.py
+++ b/world_model_server/server.py
@@ -78,6 +78,15 @@ async def main():
                             "type": "object",
                             "description": "Additional context for the query",
                         },
+                        "content_type": {
+                            "type": "string",
+                            "enum": ["rule", "fact", "procedure"],
+                            "description": (
+                                "Optional filter by content_type. Use 'procedure' "
+                                "to explicitly summon procedures (which are "
+                                "excluded from auto-injection by design)."
+                            ),
+                        },
                     },
                     "required": ["query"],
                 },
@@ -490,6 +499,7 @@ async def main():
                     query=arguments["query"],
                     entity_type=arguments.get("entity_type"),
                     context=arguments.get("context", {}),
+                    content_type=arguments.get("content_type"),
                 )
                 return [TextContent(type="text", text=result.model_dump_json(indent=2))]
 

--- a/world_model_server/tools.py
+++ b/world_model_server/tools.py
@@ -49,7 +49,11 @@ class WorldModelTools:
     # ============================================================================
 
     async def query_fact(
-        self, query: str, entity_type: Optional[str] = None, context: Dict[str, Any] = None
+        self,
+        query: str,
+        entity_type: Optional[str] = None,
+        context: Dict[str, Any] = None,
+        content_type: Optional[str] = None,
     ) -> QueryFactResult:
         """
         Query the knowledge graph for facts about entities.
@@ -58,14 +62,27 @@ class WorldModelTools:
             query: Search query (e.g., "User.findByEmail", "JWT authentication")
             entity_type: Optional filter by entity type
             context: Additional context for the query
+            content_type: Optional filter — 'rule', 'fact', or 'procedure'. When
+                set, only rows with that exact content_type are returned; NULL
+                (unclassified) rows are excluded. This is the load-bearing path
+                for explicitly summoning procedures, which are excluded from
+                auto-injection by design (v0.12.3 content-type routing).
 
         Returns:
             QueryFactResult with exists flag, matching facts, and confidence score
         """
-        logger.info(f"Querying fact: {query}, entity_type: {entity_type}")
+        logger.info(
+            f"Querying fact: {query}, entity_type: {entity_type}, "
+            f"content_type: {content_type}"
+        )
 
         # Search facts using full-text search
-        result = await self.kg.query_facts(query=query, entity_type=entity_type, current_only=True)
+        result = await self.kg.query_facts(
+            query=query,
+            entity_type=entity_type,
+            current_only=True,
+            content_type=content_type,
+        )
 
         # If no facts found, try searching entities directly
         if not result.facts:
@@ -933,32 +950,80 @@ class WorldModelTools:
         self,
         limit: int = 10,
         search: Optional[str] = None,
+        content_types: Optional[List[str]] = None,
+        exclude_content_types: Optional[List[str]] = None,
     ) -> list:
-        """Return recent canonical facts as dicts. Private helper for injection."""
+        """Return recent canonical facts as dicts. Private helper for injection.
+
+        content_types / exclude_content_types are the v0.12.3 routing hooks:
+        - content_types=[...]  -> only rows where content_type IN (...)
+                                  NULL rows are matched if 'NULL' is in the list.
+        - exclude_content_types=[...] -> rows where content_type NOT IN (...)
+                                         NULL rows are always kept unless
+                                         'NULL' is in the exclusion list.
+
+        Both filters compose. The default (both None) preserves pre-v0.12.3
+        behavior — return every canonical fact regardless of content_type.
+        """
         import aiosqlite
+
+        clauses = ["status = 'canonical'"]
+        params: List[Any] = []
+
+        if search:
+            clauses.append("fact_text LIKE ?")
+            params.append(f"%{search}%")
+
+        if content_types:
+            null_included = "NULL" in content_types
+            non_null = [c for c in content_types if c != "NULL"]
+            if non_null and null_included:
+                placeholders = ",".join("?" * len(non_null))
+                clauses.append(f"(content_type IN ({placeholders}) OR content_type IS NULL)")
+                params.extend(non_null)
+            elif non_null:
+                placeholders = ",".join("?" * len(non_null))
+                clauses.append(f"content_type IN ({placeholders})")
+                params.extend(non_null)
+            elif null_included:
+                clauses.append("content_type IS NULL")
+
+        if exclude_content_types:
+            null_excluded = "NULL" in exclude_content_types
+            non_null = [c for c in exclude_content_types if c != "NULL"]
+            if non_null and null_excluded:
+                placeholders = ",".join("?" * len(non_null))
+                clauses.append(
+                    f"(content_type NOT IN ({placeholders}) AND content_type IS NOT NULL)"
+                )
+                params.extend(non_null)
+            elif non_null:
+                placeholders = ",".join("?" * len(non_null))
+                clauses.append(
+                    f"(content_type NOT IN ({placeholders}) OR content_type IS NULL)"
+                )
+                params.extend(non_null)
+            elif null_excluded:
+                clauses.append("content_type IS NOT NULL")
+
+        where = " AND ".join(clauses)
+        sql = (
+            f"SELECT id, fact_text, valid_at, content_type FROM facts "
+            f"WHERE {where} ORDER BY valid_at DESC LIMIT ?"
+        )
+        params.append(limit)
+
         async with aiosqlite.connect(self.kg.facts_db) as db:
             db.row_factory = aiosqlite.Row
-            if search:
-                cursor = await db.execute(
-                    """
-                    SELECT id, fact_text, valid_at FROM facts
-                    WHERE status = 'canonical' AND fact_text LIKE ?
-                    ORDER BY valid_at DESC LIMIT ?
-                    """,
-                    (f"%{search}%", limit),
-                )
-            else:
-                cursor = await db.execute(
-                    """
-                    SELECT id, fact_text, valid_at FROM facts
-                    WHERE status = 'canonical'
-                    ORDER BY valid_at DESC LIMIT ?
-                    """,
-                    (limit,),
-                )
+            cursor = await db.execute(sql, params)
             rows = await cursor.fetchall()
             return [
-                {"id": r["id"], "fact_text": r["fact_text"], "valid_at": r["valid_at"]}
+                {
+                    "id": r["id"],
+                    "fact_text": r["fact_text"],
+                    "valid_at": r["valid_at"],
+                    "content_type": r["content_type"],
+                }
                 for r in rows
             ]
 
@@ -1021,15 +1086,36 @@ class WorldModelTools:
 
         event_type: one of "PostCompact", "UserPromptSubmit", "SessionStart"
         project_hint: optional substring to bias fact selection toward (e.g. file path or topic)
+
+        v0.12.3 content-type routing:
+          - content_type='rule'      always-inject; gets its own section, drawn first
+          - content_type='fact' or NULL   search-on-demand; fills remaining slots
+          - content_type='procedure' never auto-inject; excluded from this bundle
+                                     entirely (surface only via query_fact with
+                                     an explicit content_type='procedure' filter)
+
+        The max_facts budget covers both the rules section and the facts
+        section combined. Rules get preference: up to `max_facts` rules,
+        then the remainder is filled from the fact/NULL pool.
         """
         # Top constraints by violation_count (existing get_constraints orders by it desc)
         all_constraints = await self.kg.get_constraints()
         constraints = all_constraints[:max_constraints]
 
-        # Recent canonical facts: pull from facts table directly
-        facts = await self._recent_canonical_facts(
-            limit=max_facts, search=project_hint
+        # v0.12.3: two-pool routing. Rules first (always-inject), then
+        # search-on-demand facts fill remaining slots. Procedures are
+        # excluded from auto-injection by design.
+        rules = await self._recent_canonical_facts(
+            limit=max_facts,
+            search=project_hint,
+            content_types=["rule"],
         )
+        remaining = max(0, max_facts - len(rules))
+        recent_facts = await self._recent_canonical_facts(
+            limit=remaining,
+            search=project_hint,
+            content_types=["fact", "NULL"],
+        ) if remaining else []
 
         lines: list = []
         if constraints:
@@ -1039,10 +1125,18 @@ class WorldModelTools:
                     f"- {c.rule_name}: {c.description} (violated {c.violation_count}x)"
                 )
 
-        if facts:
-            lines.append("")
+        if rules:
+            if lines:
+                lines.append("")
+            lines.append("## Rules (always active)")
+            for f in rules:
+                lines.append(f"- {f['fact_text']}")
+
+        if recent_facts:
+            if lines:
+                lines.append("")
             lines.append("## Recent canonical facts")
-            for f in facts:
+            for f in recent_facts:
                 lines.append(f"- {f['fact_text']}")
 
         injection = "\n".join(lines).strip()
@@ -1050,7 +1144,8 @@ class WorldModelTools:
             {
                 "event_type": event_type,
                 "injection": injection,
-                "facts_count": len(facts),
+                "rules_count": len(rules),
+                "facts_count": len(recent_facts),
                 "constraints_count": len(constraints),
             },
             indent=2,


### PR DESCRIPTION
Replaces #23 (auto-closed when its base branch #22 merged and was deleted). Rebased onto main; no code changes.

## Summary

Closes the write-side and consumer-side loop opened by v0.11.1. That patch added `content_type` to the model and table but never wired a consumer — and worse, `create_fact` silently dropped the field on write, so callers who set it saw the value discarded. This PR fixes both ends and delivers the actual routing behavior.

## Write side

- `create_fact` now persists `content_type` + the v0.12.2 governance fields (`influence_state`, `expires_at`) in the INSERT. Backward compatible; callers who don't set them write NULL as before.
- `query_facts` hydrates all three fields into the `Fact` model on read.

## Read side

- `knowledge_graph.query_facts` accepts an optional `content_type` filter. NULL rows are always excluded when the filter is set (a NULL row is unclassified — it cannot answer a typed query).
- `tools.query_fact` exposes the same filter and passes it through.

## Injection routing (the load-bearing v0.12.3 payoff)

`get_injection_context` splits its `max_facts` budget into two pools:

| Pool | content_type | Section header | Priority |
| --- | --- | --- | --- |
| Rules | `rule` | `## Rules (always active)` | Drawn first |
| Facts | `fact` or NULL | `## Recent canonical facts` | Fills the remainder |
| Procedures | `procedure` | (excluded) | Only via `query_fact` with `content_type='procedure'` |

Return payload gains `rules_count` alongside `facts_count` and `constraints_count` so callers can see which pool contributed.

## Surface exposure

- MCP `query_fact` schema in `server.py` gains the `content_type` enum
- Hermes surfaced tool schema in the MemoryProvider mirrors it
- MCP call-tool dispatch passes `content_type` through

## Docs

`hermes_memory_provider/README.md` documents the routing semantics as a table.

## Test plan

- [x] 18 new tests in `tests/test_v0123_content_type_routing.py`
- [x] W1: regression against v0.11.1's silent drop on write
- [x] R1: filter behavior, NULL exclusion, hydration
- [x] I1/I2/I3: injection routing, procedure exclusion + explicit summon, rules-first budget
- [x] B1: NULL rows behave as `fact` for auto-inject
- [x] S1: MCP + Hermes surfaced schemas expose `content_type`
- [x] Full suite: 498 pass (main baseline after #21/#22 = 480; +18)
- [x] Contradictions benchmark: 105/105