### PR TITLE
v0.12.4: GitHub Copilot Chat adapter (install-copilot)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ packages = ["world_model_server"]
 "world_model_server/adapters/codex/config.toml" = "world_model_server/adapters/codex/config.toml"
 "world_model_server/adapters/codex/hooks_snippet.toml" = "world_model_server/adapters/codex/hooks_snippet.toml"
 "world_model_server/adapters/openclaw/openclaw.json" = "world_model_server/adapters/openclaw/openclaw.json"
+"world_model_server/adapters/copilot/mcp.json" = "world_model_server/adapters/copilot/mcp.json"
 "world_model_server/adapters/hermes/config-snippet.yaml" = "world_model_server/adapters/hermes/config-snippet.yaml"
 "world_model_server/hermes_memory_provider/__init__.py" = "world_model_server/hermes_memory_provider/__init__.py"
 "world_model_server/hermes_memory_provider/plugin.yaml" = "world_model_server/hermes_memory_provider/plugin.yaml"

--- a/tests/test_v0124_install_copilot.py
+++ b/tests/test_v0124_install_copilot.py
@@ -1,0 +1,267 @@
+"""
+v0.12.4: install-copilot adapter.
+
+Registers world-model-mcp with GitHub Copilot Chat in VS Code by merging
+into .vscode/mcp.json. VS Code uses a top-level ``servers`` key (not
+``mcpServers`` like Claude Code / Cursor). Users commonly already have
+this file populated with other MCP servers (github, playwright, etc.),
+so the installer MUST merge — an overwrite would silently blow away
+their existing config.
+
+Regression discipline:
+  - fresh install writes the bundled template intact
+  - existing file with other servers: our entry is added, others preserved
+  - existing file with a stale world-model entry: skipped unless --force
+  - --force overwrites ONLY the world-model key; other servers preserved
+  - malformed JSON: refuse with a clear error, exit nonzero
+  - top-level not-an-object: refuse with a clear error
+  - 'servers' not-an-object: refuse with a clear error
+  - --dry-run does not touch disk
+  - the bundled adapter file is well-formed JSON with the right shape
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from world_model_server.cli import install_copilot_command
+
+
+REPO_ROOT = Path(__file__).parent.parent
+BUNDLED = REPO_ROOT / "world_model_server" / "adapters" / "copilot" / "mcp.json"
+
+
+# ---------------------------------------------------------------------------
+# B: bundled adapter file sanity
+# ---------------------------------------------------------------------------
+
+
+def test_b1_bundled_adapter_exists():
+    assert BUNDLED.exists(), f"Bundled adapter missing: {BUNDLED}"
+
+
+def test_b1_bundled_adapter_uses_vscode_servers_key():
+    """VS Code Copilot Chat MCP config uses 'servers', NOT 'mcpServers'."""
+    data = json.loads(BUNDLED.read_text())
+    assert "servers" in data, "Bundled adapter must use VS Code's 'servers' key"
+    assert "mcpServers" not in data, (
+        "The 'mcpServers' key is Claude Code / Cursor convention; VS Code "
+        "Copilot Chat does not read it."
+    )
+
+
+def test_b1_bundled_adapter_registers_world_model():
+    data = json.loads(BUNDLED.read_text())
+    assert "world-model" in data["servers"]
+    entry = data["servers"]["world-model"]
+    assert entry["command"] == "python3"
+    assert entry["args"] == ["-m", "world_model_server.server"]
+
+
+# ---------------------------------------------------------------------------
+# I: installer behavior
+# ---------------------------------------------------------------------------
+
+
+def _run(tmp_path, *, force=False, dry_run=False):
+    args = SimpleNamespace(
+        project_dir=str(tmp_path),
+        force=force,
+        dry_run=dry_run,
+    )
+    install_copilot_command(args)
+
+
+def test_i1_fresh_install_creates_vscode_mcp_json(tmp_path):
+    _run(tmp_path)
+    target = tmp_path / ".vscode" / "mcp.json"
+    assert target.exists()
+    data = json.loads(target.read_text())
+    assert "world-model" in data["servers"]
+
+
+def test_i1_fresh_install_matches_bundled_template(tmp_path):
+    _run(tmp_path)
+    target = tmp_path / ".vscode" / "mcp.json"
+    written = json.loads(target.read_text())
+    bundled = json.loads(BUNDLED.read_text())
+    assert written == bundled
+
+
+def test_i2_merge_preserves_other_servers(tmp_path):
+    """The load-bearing regression: an existing github entry must survive."""
+    vscode = tmp_path / ".vscode"
+    vscode.mkdir()
+    existing = {
+        "servers": {
+            "github": {
+                "type": "http",
+                "url": "https://api.githubcopilot.com/mcp",
+            },
+            "playwright": {
+                "command": "npx",
+                "args": ["-y", "@microsoft/mcp-server-playwright"],
+            },
+        }
+    }
+    (vscode / "mcp.json").write_text(json.dumps(existing, indent=2))
+    _run(tmp_path)
+    data = json.loads((vscode / "mcp.json").read_text())
+    assert "github" in data["servers"], "github MCP entry got clobbered"
+    assert "playwright" in data["servers"], "playwright entry got clobbered"
+    assert data["servers"]["github"]["url"] == "https://api.githubcopilot.com/mcp"
+    assert "world-model" in data["servers"]
+
+
+def test_i2_merge_preserves_top_level_non_servers_keys(tmp_path):
+    """VS Code mcp.json may include an inputs array and other keys — those
+    must not be touched."""
+    vscode = tmp_path / ".vscode"
+    vscode.mkdir()
+    existing = {
+        "inputs": [{"type": "promptString", "id": "gh_token"}],
+        "servers": {"github": {"type": "http", "url": "https://x.example"}},
+    }
+    (vscode / "mcp.json").write_text(json.dumps(existing, indent=2))
+    _run(tmp_path)
+    data = json.loads((vscode / "mcp.json").read_text())
+    assert data.get("inputs") == existing["inputs"]
+
+
+def test_i3_existing_world_model_entry_skipped_without_force(tmp_path, capsys):
+    vscode = tmp_path / ".vscode"
+    vscode.mkdir()
+    existing = {"servers": {"world-model": {"command": "user-custom-cmd"}}}
+    (vscode / "mcp.json").write_text(json.dumps(existing, indent=2))
+    _run(tmp_path)
+    data = json.loads((vscode / "mcp.json").read_text())
+    # User's custom command must survive
+    assert data["servers"]["world-model"]["command"] == "user-custom-cmd"
+
+
+def test_i3_force_overwrites_world_model_only(tmp_path):
+    vscode = tmp_path / ".vscode"
+    vscode.mkdir()
+    existing = {
+        "servers": {
+            "world-model": {"command": "user-custom-cmd"},
+            "github": {"type": "http", "url": "https://x.example"},
+        }
+    }
+    (vscode / "mcp.json").write_text(json.dumps(existing, indent=2))
+    _run(tmp_path, force=True)
+    data = json.loads((vscode / "mcp.json").read_text())
+    # world-model is now the bundled entry
+    bundled = json.loads(BUNDLED.read_text())
+    assert data["servers"]["world-model"] == bundled["servers"]["world-model"]
+    # github is preserved
+    assert data["servers"]["github"]["url"] == "https://x.example"
+
+
+def test_i4_file_without_servers_key_gets_servers_added(tmp_path):
+    """A user could have `.vscode/mcp.json` with `inputs` but no `servers`.
+    We add the `servers` key without disturbing anything else."""
+    vscode = tmp_path / ".vscode"
+    vscode.mkdir()
+    existing = {"inputs": [{"type": "promptString", "id": "x"}]}
+    (vscode / "mcp.json").write_text(json.dumps(existing, indent=2))
+    _run(tmp_path)
+    data = json.loads((vscode / "mcp.json").read_text())
+    assert "servers" in data
+    assert "world-model" in data["servers"]
+    assert data["inputs"] == existing["inputs"]
+
+
+# ---------------------------------------------------------------------------
+# E: error paths (refuse rather than corrupt)
+# ---------------------------------------------------------------------------
+
+
+def test_e1_malformed_json_refused(tmp_path):
+    vscode = tmp_path / ".vscode"
+    vscode.mkdir()
+    (vscode / "mcp.json").write_text("{not-json}")
+    with pytest.raises(SystemExit):
+        _run(tmp_path)
+    # File left untouched
+    assert (vscode / "mcp.json").read_text() == "{not-json}"
+
+
+def test_e2_top_level_array_refused(tmp_path):
+    vscode = tmp_path / ".vscode"
+    vscode.mkdir()
+    (vscode / "mcp.json").write_text("[]")
+    with pytest.raises(SystemExit):
+        _run(tmp_path)
+    assert (vscode / "mcp.json").read_text() == "[]"
+
+
+def test_e3_servers_not_object_refused(tmp_path):
+    vscode = tmp_path / ".vscode"
+    vscode.mkdir()
+    (vscode / "mcp.json").write_text('{"servers": ["not-an-object"]}')
+    with pytest.raises(SystemExit):
+        _run(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# D: --dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_d1_dry_run_does_not_create_file(tmp_path):
+    _run(tmp_path, dry_run=True)
+    assert not (tmp_path / ".vscode" / "mcp.json").exists()
+
+
+def test_d1_dry_run_does_not_modify_existing_file(tmp_path):
+    vscode = tmp_path / ".vscode"
+    vscode.mkdir()
+    original = json.dumps({"servers": {"github": {"type": "http", "url": "https://x"}}}, indent=2)
+    (vscode / "mcp.json").write_text(original)
+    _run(tmp_path, dry_run=True)
+    assert (vscode / "mcp.json").read_text() == original
+
+
+# ---------------------------------------------------------------------------
+# C: CLI wiring
+# ---------------------------------------------------------------------------
+
+
+def test_c1_subcommand_registered_in_cli_help():
+    """world-model install-copilot must appear in the top-level help."""
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "--help"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    assert "install-copilot" in result.stdout
+
+
+def test_c1_subcommand_dry_run_via_cli(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "world_model_server.cli",
+            "install-copilot",
+            "--project-dir", str(tmp_path),
+            "--dry-run",
+        ],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    # Should print the merged JSON — check for a signature substring
+    assert "world-model" in result.stdout
+    assert "servers" in result.stdout
+    assert not (tmp_path / ".vscode" / "mcp.json").exists()

--- a/world_model_server/adapters/copilot/mcp.json
+++ b/world_model_server/adapters/copilot/mcp.json
@@ -1,0 +1,11 @@
+{
+  "servers": {
+    "world-model": {
+      "command": "python3",
+      "args": ["-m", "world_model_server.server"],
+      "env": {
+        "WORLD_MODEL_DB_PATH": ".claude/world-model"
+      }
+    }
+  }
+}

--- a/world_model_server/cli.py
+++ b/world_model_server/cli.py
@@ -1053,6 +1053,101 @@ def install_codex_command(args):
     )
 
 
+def install_copilot_command(args):
+    """Register world-model-mcp with GitHub Copilot Chat in VS Code by
+    merging into ``.vscode/mcp.json``.
+
+    VS Code's Copilot Chat reads MCP servers from a top-level ``servers``
+    key (distinct from the ``mcpServers`` convention used by Claude Code,
+    Cursor, etc. — see .vscode/mcp.json docs). Users commonly already
+    have this file populated with other servers (github, playwright,
+    etc.), so this installer MERGES rather than overwrites: it parses
+    the existing JSON, adds a ``world-model`` entry under ``servers``,
+    and preserves every other key exactly.
+
+    Behavior matrix:
+      - file absent      -> write the full bundled template
+      - file present, no ``world-model`` under ``servers``
+                         -> merge our entry, preserve rest
+      - file present, ``world-model`` under ``servers`` already
+                         -> skip unless --force; --force overwrites
+                            just that one key
+      - file present, malformed JSON
+                         -> refuse to write; user must fix manually
+
+    Options:
+      --project-dir DIR  target project (default: cwd)
+      --force            overwrite an existing ``servers.world-model`` entry
+      --dry-run          print what would change without writing
+    """
+    import json
+
+    project_dir = Path(args.project_dir).resolve()
+    vscode_dir = project_dir / ".vscode"
+    target = vscode_dir / "mcp.json"
+
+    pkg_root = Path(__file__).parent
+    adapter_src = pkg_root / "adapters" / "copilot" / "mcp.json"
+    if not adapter_src.exists():
+        console.print(f"[red]Missing bundled adapter file: {adapter_src}[/red]")
+        sys.exit(1)
+
+    bundled = json.loads(adapter_src.read_text())
+    our_entry = bundled["servers"]["world-model"]
+
+    if target.exists():
+        try:
+            existing = json.loads(target.read_text())
+        except json.JSONDecodeError as e:
+            console.print(
+                f"[red]Refusing to touch malformed JSON at {target}: {e}[/red]\n"
+                "Fix the file by hand and re-run."
+            )
+            sys.exit(1)
+        if not isinstance(existing, dict):
+            console.print(
+                f"[red]Refusing to touch {target}: top-level value must be an object, "
+                f"got {type(existing).__name__}[/red]"
+            )
+            sys.exit(1)
+        servers = existing.get("servers")
+        if servers is not None and not isinstance(servers, dict):
+            console.print(
+                f"[red]Refusing to touch {target}: 'servers' must be an object, "
+                f"got {type(servers).__name__}[/red]"
+            )
+            sys.exit(1)
+        if servers is None:
+            existing["servers"] = {}
+            servers = existing["servers"]
+        if "world-model" in servers and not args.force:
+            console.print(
+                f"[yellow]world-model already registered in {target}[/yellow]\n"
+                "Use --force to overwrite that entry (other servers preserved)."
+            )
+            return
+        servers["world-model"] = our_entry
+        merged = existing
+    else:
+        merged = bundled
+
+    if args.dry_run:
+        console.print(f"[bold]Would write:[/bold] {target}")
+        console.print(json.dumps(merged, indent=2))
+        return
+
+    vscode_dir.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(merged, indent=2) + "\n")
+
+    console.print(f"[green]Copilot adapter installed[/green]")
+    console.print(f"  + {target.relative_to(project_dir)}")
+    console.print(
+        "\nNext: reload the VS Code window (Cmd/Ctrl+Shift+P -> 'Developer: "
+        "Reload Window'). Verify Copilot picks up the server via "
+        "Cmd/Ctrl+Shift+P -> 'MCP: List Servers' -> 'world-model'."
+    )
+
+
 def install_pi_command(args):
     """Copy the pi adapter (index.ts, package.json) into ./adapters/world-model-pi/.
 
@@ -1356,6 +1451,24 @@ def main():
     cursor_parser.add_argument("--project-dir", type=str, default=".")
     cursor_parser.add_argument("--force", action="store_true", help="Overwrite existing files")
     cursor_parser.set_defaults(func=install_cursor_command)
+
+    copilot_parser = subparsers.add_parser(
+        "install-copilot",
+        help=(
+            "Register world-model with GitHub Copilot Chat in VS Code by "
+            "merging into .vscode/mcp.json (preserves other servers)"
+        ),
+    )
+    copilot_parser.add_argument("--project-dir", type=str, default=".")
+    copilot_parser.add_argument(
+        "--force", action="store_true",
+        help="Overwrite an existing 'servers.world-model' entry",
+    )
+    copilot_parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print the merged JSON that would be written; don't touch disk",
+    )
+    copilot_parser.set_defaults(func=install_copilot_command)
 
     pi_parser = subparsers.add_parser(
         "install-pi", help="Install the pi adapter to ./adapters/world-model-pi/"


### PR DESCRIPTION
## Summary

Registers world-model-mcp with GitHub Copilot Chat in VS Code by merging into `.vscode/mcp.json`. Copilot has an order-of-magnitude larger paid seat count than any adapter we currently ship — it was missed in the v0.10 breadth pass.

## VS Code specifics

- **Config path:** `.vscode/mcp.json` (workspace-local)
- **Top-level key:** `"servers"` — **NOT** `"mcpServers"` like every other adapter we ship. Getting this wrong silently registers nothing.
- Stdio transport uses the same `command` / `args` shape as our other MCP registrations; no server-side changes needed.

## Merge semantics (the load-bearing detail)

Users routinely have `.vscode/mcp.json` populated with the github MCP server, playwright, etc. A blanket overwrite would delete that config with no recovery. So the installer merges:

| State | Behavior |
| --- | --- |
| File absent | Write bundled template |
| File present, no `world-model` under `servers` | Add our entry, preserve everything else |
| File present, `world-model` already there | Skip unless `--force` |
| `--force` | Overwrite ONLY `servers.world-model`; other servers preserved |
| Malformed JSON | Refuse with clear error, exit nonzero, leave file untouched |
| Top-level not an object | Refuse |
| `servers` not an object | Refuse |

Non-`servers` top-level keys (e.g. `inputs`) are preserved. `--dry-run` prints the merged JSON without touching disk.

## Packaging

`adapters/copilot/mcp.json` added to `[tool.hatch.build.targets.wheel.force-include]` in pyproject.toml so it ships with `pip install world-model-mcp`.

## Test plan

- [x] 17 new tests in `tests/test_v0124_install_copilot.py`
- [x] B1: bundled file uses `servers` key (not `mcpServers`), registers world-model with expected stdio shape
- [x] I1–I4: fresh install, merge preserves other servers, merge preserves non-servers keys, skip-without-force, `--force` overwrites only world-model, file-without-servers gets `servers` added
- [x] E1–E3: malformed JSON refused, top-level array refused, non-object `servers` refused
- [x] D1: `--dry-run` does not create or modify anything
- [x] C1: subcommand appears in `world-model --help`; CLI `--dry-run` works end-to-end via subprocess
- [x] Full suite: 539 pass (was 522; +17)
- [x] Contradictions benchmark: 105/105