### PR TITLE
v0.12.5: install-continue --global config-merge path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ http = [
 hermes = [
     "ruamel.yaml>=0.17",
 ]
+continue = [
+    "ruamel.yaml>=0.17",
+]
 
 [project.scripts]
 world-model = "world_model_server.cli:main"

--- a/tests/test_v0125_install_continue_global.py
+++ b/tests/test_v0125_install_continue_global.py
@@ -1,0 +1,282 @@
+"""
+v0.12.5: install-continue --global config-merge path.
+
+The v0.10 install-continue writes a standalone per-project YAML at
+.continue/mcpServers/world-model.yaml. v0.12.5 adds --global which
+merges into the user-global ~/.continue/config.yaml instead. Continue's
+schema puts mcpServers as a LIST of entries (each with a `name` key),
+NOT a mapping — this is distinct from Hermes' mcp_servers-mapping shape,
+and merge logic is written for the list case specifically.
+
+Regression discipline:
+  - fresh install (no file) creates a config.yaml with a single-entry
+    mcpServers list
+  - existing file with other mcpServers entries: our entry is appended,
+    others preserved and their positions kept
+  - existing file with a world-model entry: skipped unless --force
+  - --force replaces the world-model entry in place (other entries at
+    their original indices)
+  - top-level non-mcpServers keys preserved
+  - ruamel.yaml round-trip preserves comments
+  - malformed YAML: refused with clear error
+  - mcpServers-not-a-list: refused
+  - --dry-run does not touch disk
+  - per-project mode (no --global) still works unchanged (v0.10
+    behavior contract)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from world_model_server.cli import install_continue_command
+
+
+# ruamel.yaml is now required for --global — skip the whole suite if
+# not installed rather than failing every test.
+pytest.importorskip("ruamel.yaml")
+
+from ruamel.yaml import YAML  # noqa: E402
+
+
+def _load(path: Path):
+    return YAML().load(path.read_text())
+
+
+def _run(tmp_path, *, use_global=True, force=False, dry_run=False, config_path=None):
+    args = SimpleNamespace(
+        project_dir=str(tmp_path),
+        global_config=use_global,
+        config_path=config_path,
+        python="/usr/bin/python3",
+        db_path=None,
+        force=force,
+        dry_run=dry_run,
+    )
+    install_continue_command(args)
+
+
+# ---------------------------------------------------------------------------
+# Fresh install
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_global_install_creates_config(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    _run(tmp_path, config_path=str(cfg))
+    assert cfg.exists()
+    data = _load(cfg)
+    assert isinstance(data["mcpServers"], list)
+    assert len(data["mcpServers"]) == 1
+    entry = data["mcpServers"][0]
+    assert entry["name"] == "world-model"
+    assert entry["type"] == "stdio"
+    assert entry["command"] == "/usr/bin/python3"
+    assert entry["args"] == ["-m", "world_model_server.server"]
+    assert entry["env"]["WORLD_MODEL_DB_PATH"] == ".claude/world-model"
+
+
+# ---------------------------------------------------------------------------
+# Merge: other entries preserved
+# ---------------------------------------------------------------------------
+
+
+def test_merge_appends_and_preserves_other_entries(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "mcpServers:\n"
+        "  - name: sqlite\n"
+        "    type: stdio\n"
+        "    command: npx\n"
+        "    args: [-y, mcp-sqlite]\n"
+        "  - name: playwright\n"
+        "    type: stdio\n"
+        "    command: npx\n"
+        "    args: [-y, '@microsoft/mcp-server-playwright']\n"
+    )
+    _run(tmp_path, config_path=str(cfg))
+    data = _load(cfg)
+    names = [e["name"] for e in data["mcpServers"]]
+    assert names == ["sqlite", "playwright", "world-model"], (
+        "Existing entries must be preserved in order; ours appended last."
+    )
+
+
+def test_merge_preserves_top_level_non_mcp_servers_keys(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "name: my-continue-config\n"
+        "version: 0.0.1\n"
+        "schema: v1\n"
+        "models:\n"
+        "  - name: claude\n"
+        "    provider: anthropic\n"
+        "mcpServers:\n"
+        "  - name: sqlite\n"
+        "    command: npx\n"
+    )
+    _run(tmp_path, config_path=str(cfg))
+    data = _load(cfg)
+    assert data.get("name") == "my-continue-config"
+    assert data.get("version") == "0.0.1"
+    assert data.get("schema") == "v1"
+    assert data["models"][0]["name"] == "claude"
+
+
+def test_merge_comments_survive_round_trip(tmp_path):
+    """The whole reason install-hermes uses ruamel.yaml is comment
+    preservation. Same guarantee must hold for --global here."""
+    cfg = tmp_path / "config.yaml"
+    original = (
+        "# My personal continue setup — DO NOT DELETE\n"
+        "name: my-config\n"
+        "# List of MCP servers I use across projects\n"
+        "mcpServers:\n"
+        "  - name: sqlite\n"
+        "    command: npx\n"
+    )
+    cfg.write_text(original)
+    _run(tmp_path, config_path=str(cfg))
+    text = cfg.read_text()
+    assert "# My personal continue setup — DO NOT DELETE" in text
+    assert "# List of MCP servers I use across projects" in text
+
+
+# ---------------------------------------------------------------------------
+# Existing world-model entry: skip vs --force
+# ---------------------------------------------------------------------------
+
+
+def test_existing_world_model_entry_skipped_without_force(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "mcpServers:\n"
+        "  - name: world-model\n"
+        "    command: user-custom-path\n"
+        "    args: [--custom]\n"
+    )
+    _run(tmp_path, config_path=str(cfg))
+    data = _load(cfg)
+    # User's custom command untouched
+    assert data["mcpServers"][0]["command"] == "user-custom-path"
+
+
+def test_force_replaces_world_model_entry_in_place(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "mcpServers:\n"
+        "  - name: sqlite\n"
+        "    command: npx\n"
+        "  - name: world-model\n"
+        "    command: old-path\n"
+        "  - name: playwright\n"
+        "    command: npx\n"
+    )
+    _run(tmp_path, config_path=str(cfg), force=True)
+    data = _load(cfg)
+    names = [e["name"] for e in data["mcpServers"]]
+    # Order preserved — world-model still at index 1
+    assert names == ["sqlite", "world-model", "playwright"]
+    # And its command is now the fresh value
+    assert data["mcpServers"][1]["command"] == "/usr/bin/python3"
+
+
+# ---------------------------------------------------------------------------
+# Structural errors: refuse rather than corrupt
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_yaml_refused(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("this: is: not: valid: yaml: [\n")
+    original = cfg.read_text()
+    with pytest.raises(SystemExit):
+        _run(tmp_path, config_path=str(cfg))
+    assert cfg.read_text() == original
+
+
+def test_mcp_servers_not_a_list_refused(tmp_path):
+    """Continue's schema wants a list. If a user has a mapping (Hermes
+    style), refuse rather than silently break their config."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "mcpServers:\n"
+        "  world-model:\n"
+        "    command: foo\n"
+    )
+    original = cfg.read_text()
+    with pytest.raises(SystemExit):
+        _run(tmp_path, config_path=str(cfg))
+    assert cfg.read_text() == original
+
+
+def test_top_level_not_mapping_refused(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("- just\n- a\n- list\n")
+    original = cfg.read_text()
+    with pytest.raises(SystemExit):
+        _run(tmp_path, config_path=str(cfg))
+    assert cfg.read_text() == original
+
+
+# ---------------------------------------------------------------------------
+# --dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_does_not_create_file(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    _run(tmp_path, config_path=str(cfg), dry_run=True)
+    assert not cfg.exists()
+
+
+def test_dry_run_does_not_modify_existing(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    original = "mcpServers:\n  - name: sqlite\n    command: npx\n"
+    cfg.write_text(original)
+    _run(tmp_path, config_path=str(cfg), dry_run=True)
+    assert cfg.read_text() == original
+
+
+# ---------------------------------------------------------------------------
+# --python validation still fires under --global
+# ---------------------------------------------------------------------------
+
+
+def test_relative_python_rejected_in_global_mode(tmp_path):
+    args = SimpleNamespace(
+        project_dir=str(tmp_path),
+        global_config=True,
+        config_path=str(tmp_path / "config.yaml"),
+        python="python3",
+        db_path=None,
+        force=False,
+        dry_run=False,
+    )
+    with pytest.raises(SystemExit):
+        install_continue_command(args)
+
+
+# ---------------------------------------------------------------------------
+# Per-project mode still works (v0.10 behavior contract)
+# ---------------------------------------------------------------------------
+
+
+def test_per_project_mode_still_writes_standalone_yaml(tmp_path):
+    """--global unset -> per-project behavior identical to v0.10."""
+    _run(tmp_path, use_global=False)
+    target = tmp_path / ".continue" / "mcpServers" / "world-model.yaml"
+    assert target.exists()
+    text = target.read_text()
+    assert "name: world-model-mcp" in text
+    assert "  - name: world-model" in text
+    assert "WORLD_MODEL_DB_PATH: .claude/world-model" in text
+
+
+def test_per_project_mode_does_not_touch_home_config(tmp_path):
+    """Per-project mode must NEVER read or write ~/.continue/config.yaml."""
+    _run(tmp_path, use_global=False)
+    assert not (tmp_path / "config.yaml").exists()

--- a/world_model_server/cli.py
+++ b/world_model_server/cli.py
@@ -918,21 +918,30 @@ def install_hermes_command(args):
 def install_continue_command(args):
     """Register world-model-mcp as an MCP server in Continue.
 
-    Writes a standalone YAML file at
+    Two modes:
+
+    Per-project (default): writes a standalone YAML file at
     <project-dir>/.continue/mcpServers/world-model.yaml, matching
-    Continue's documented per-server-file pattern. No config merge is
-    needed because Continue expects one YAML per MCP server in that
-    directory — we own the whole file.
+    Continue's per-server-file pattern. No merge needed — we own the
+    file end-to-end.
 
-    Defaults --python to sys.executable (absolute path). Rejects relative
-    --python overrides as a hard error, matching the OpenClaw and Hermes
-    adapters. No ruamel.yaml dependency needed because we author the
-    file end-to-end (no comment preservation problem to solve).
+    Global (--global): merges into ~/.continue/config.yaml's top-level
+    ``mcpServers`` LIST, preserving comments and every other entry.
+    The list-entry shape follows Continue's documented schema:
+      - name: world-model
+        type: stdio
+        command: <python>
+        args: [-m, world_model_server.server]
+        env: {WORLD_MODEL_DB_PATH: ...}
+    An existing world-model entry (matched by name) is skipped unless
+    --force, in which case it is replaced in place (other entries
+    keep their position). Global mode requires ruamel.yaml — install
+    with `pip install "world-model-mcp[continue]"` or `[hermes]`.
+
+    Defaults --python to sys.executable (absolute path). Rejects
+    relative --python overrides as a hard error, matching Hermes /
+    OpenClaw.
     """
-    project_dir = Path(args.project_dir).resolve()
-    mcp_servers_dir = project_dir / ".continue" / "mcpServers"
-    target = mcp_servers_dir / "world-model.yaml"
-
     python_bin = args.python or sys.executable
     if not Path(python_bin).is_absolute():
         console.print(
@@ -943,6 +952,15 @@ def install_continue_command(args):
         sys.exit(1)
 
     db_path = args.db_path or ".claude/world-model"
+
+    if getattr(args, "global_config", False):
+        _install_continue_global(args, python_bin=python_bin, db_path=db_path)
+        return
+
+    # Per-project mode (v0.10 behavior, unchanged).
+    project_dir = Path(args.project_dir).resolve()
+    mcp_servers_dir = project_dir / ".continue" / "mcpServers"
+    target = mcp_servers_dir / "world-model.yaml"
 
     yaml_body = (
         "name: world-model-mcp\n"
@@ -983,6 +1001,125 @@ def install_continue_command(args):
         "\nNext: reload the Continue extension (reopen the VS Code / JetBrains\n"
         "window, or reload the extension) so it picks up the new server.\n"
         "Then open agent mode and confirm world-model tools are visible."
+    )
+
+
+def _install_continue_global(args, python_bin: str, db_path: str) -> None:
+    """Merge world-model into the user-global ~/.continue/config.yaml.
+
+    Continue's schema puts mcpServers as a LIST of entries (each with a
+    ``name`` key), NOT a mapping keyed by name. This function preserves
+    entry order and every other top-level key, and uses ruamel.yaml
+    round-trip mode so comments and blank lines survive.
+    """
+    try:
+        from ruamel.yaml import YAML
+        from ruamel.yaml.error import YAMLError
+        from ruamel.yaml.comments import CommentedMap, CommentedSeq
+    except ImportError:
+        console.print(
+            "[red]install-continue --global requires ruamel.yaml.[/red]\n"
+            'Install with: pip install "world-model-mcp[continue]"'
+        )
+        sys.exit(1)
+
+    config_path = Path(args.config_path).expanduser().resolve() if args.config_path else (
+        Path.home() / ".continue" / "config.yaml"
+    )
+
+    yaml_rt = YAML()
+    yaml_rt.preserve_quotes = True
+    yaml_rt.indent(mapping=2, sequence=4, offset=2)
+
+    if config_path.exists():
+        try:
+            existing = yaml_rt.load(config_path.read_text())
+        except YAMLError as exc:
+            console.print(
+                f"[red]Failed to parse {config_path} as YAML: {exc}[/red]\n"
+                "Fix the config file by hand or delete it and rerun."
+            )
+            sys.exit(1)
+        if existing is None:
+            existing = CommentedMap()
+    else:
+        existing = CommentedMap()
+
+    if not isinstance(existing, dict):
+        console.print(
+            f"[red]{config_path} did not parse as a YAML mapping; refusing to write.[/red]"
+        )
+        sys.exit(1)
+
+    servers_list = existing.get("mcpServers")
+    if servers_list is None:
+        existing["mcpServers"] = CommentedSeq()
+        servers_list = existing["mcpServers"]
+    if not isinstance(servers_list, list):
+        console.print(
+            f"[red]mcpServers in {config_path} is not a YAML list; refusing to write.[/red]\n"
+            "Continue's schema requires mcpServers to be a list of server entries."
+        )
+        sys.exit(1)
+
+    def _build_entry():
+        entry = CommentedMap()
+        entry["name"] = "world-model"
+        entry["type"] = "stdio"
+        entry["command"] = python_bin
+        entry_args = CommentedSeq()
+        entry_args.append("-m")
+        entry_args.append("world_model_server.server")
+        entry["args"] = entry_args
+        env = CommentedMap()
+        env["WORLD_MODEL_DB_PATH"] = db_path
+        entry["env"] = env
+        return entry
+
+    existing_index = None
+    for i, entry in enumerate(servers_list):
+        if isinstance(entry, dict) and entry.get("name") == "world-model":
+            existing_index = i
+            break
+
+    if existing_index is not None and not args.force:
+        console.print(
+            f"[yellow]world-model already present in {config_path} "
+            f"(mcpServers[{existing_index}])[/yellow]\n"
+            "Use --force to replace that entry in place. Other entries preserved."
+        )
+        return
+
+    if args.dry_run:
+        import io
+        console.print(f"[bold]Would write to:[/bold] {config_path}")
+        console.print("\n--- proposed mcpServers entry ---\n")
+        buf = io.StringIO()
+        yaml_rt.dump(_build_entry(), buf)
+        console.print(buf.getvalue())
+        if existing_index is not None:
+            console.print(f"(would replace existing entry at index {existing_index})")
+        else:
+            console.print(f"(would append to the end of a {len(servers_list)}-entry list)")
+        return
+
+    new_entry = _build_entry()
+    if existing_index is not None:
+        servers_list[existing_index] = new_entry
+    else:
+        servers_list.append(new_entry)
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with config_path.open("w") as f:
+        yaml_rt.dump(existing, f)
+
+    console.print("[green]Continue adapter installed globally[/green]")
+    console.print(f"  Merged into {config_path}")
+    console.print(f"  command: {python_bin}")
+    console.print(f"  WORLD_MODEL_DB_PATH: {db_path}")
+    console.print(
+        "\nNext: reload the Continue extension in every editor window that "
+        "has it active."
     )
 
 
@@ -1581,11 +1718,31 @@ def main():
 
     continue_parser = subparsers.add_parser(
         "install-continue",
-        help="Wire world-model-mcp into Continue by writing .continue/mcpServers/world-model.yaml",
+        help=(
+            "Wire world-model-mcp into Continue. Default: writes "
+            ".continue/mcpServers/world-model.yaml per project. "
+            "--global: merges into ~/.continue/config.yaml instead."
+        ),
     )
     continue_parser.add_argument(
         "--project-dir", type=str, default=".",
-        help="Project directory to install into (default: current directory)",
+        help="Project directory to install into (default: current). Ignored with --global.",
+    )
+    continue_parser.add_argument(
+        "--global", dest="global_config", action="store_true",
+        help=(
+            "Merge into the user-global ~/.continue/config.yaml instead of "
+            "writing a per-project file. Preserves other mcpServers entries "
+            "and every comment. Requires ruamel.yaml (install with "
+            "'pip install \"world-model-mcp[continue]\"')."
+        ),
+    )
+    continue_parser.add_argument(
+        "--config-path", type=str, default=None,
+        help=(
+            "Override the global config path (only meaningful with --global; "
+            "default ~/.continue/config.yaml)."
+        ),
     )
     continue_parser.add_argument(
         "--python", type=str, default=None,
@@ -1601,11 +1758,14 @@ def main():
     )
     continue_parser.add_argument(
         "--force", action="store_true",
-        help="Overwrite the existing world-model.yaml file if present",
+        help=(
+            "Per-project mode: overwrite existing world-model.yaml. "
+            "--global mode: replace the existing world-model entry in place."
+        ),
     )
     continue_parser.add_argument(
         "--dry-run", action="store_true",
-        help="Print the YAML that would be written without touching disk",
+        help="Print what would be written without touching disk",
     )
     continue_parser.set_defaults(func=install_continue_command)
 


### PR DESCRIPTION
## Summary

Adds a `--global` flag to `install-continue` that merges into `~/.continue/config.yaml` instead of writing a per-project file. Deferred from v0.10; unblocks Continue users who want world-model available across every project they open.

## Merge shape

Continue's `mcpServers` is a **list** of entries with a `name` key — distinct from every other adapter we ship (Hermes' `mcp_servers` mapping, Claude Code / Cursor / Copilot's `mcpServers` mapping). Merge logic is written for the list case.

| State | Behavior |
| --- | --- |
| File absent | Create with single-entry list |
| No `world-model` entry | Append, preserve every other entry's position and content |
| `world-model` already present | Skip unless `--force` |
| `--force` | Replace `world-model` entry in place (other entries keep their indices) |
| Malformed YAML | Refuse, exit nonzero, leave file untouched |
| `mcpServers` not a list | Refuse (someone using Hermes shape) |
| Top-level not a mapping | Refuse |

`--dry-run` prints the proposed entry without touching disk.

## Comment preservation

Round-trip via `ruamel.yaml` so comments, blank lines, and key ordering are preserved. Continue's config.yaml is often heavily commented (personal model roster, provider notes) — a naive YAML rewrite would strip all of it.

## Packaging

New optional extra `[continue]` providing `ruamel.yaml`, mirroring `[hermes]`. Either extra satisfies the requirement.

## Per-project mode contract

`install-continue` without `--global` still writes `.continue/mcpServers/world-model.yaml` exactly as it did in v0.10. That contract is under regression coverage.

## Test plan

- [x] 14 new tests in `tests/test_v0125_install_continue_global.py`
- [x] Fresh install, merge appends and preserves order, top-level keys preserved, comments survive round-trip
- [x] Skip-without-force behavior; `--force` replaces in place at the same index
- [x] Malformed YAML refused, mapping-shape `mcpServers` refused, top-level list refused
- [x] `--dry-run` no-op (fresh + existing)
- [x] Relative `--python` rejected in `--global` mode
- [x] Per-project mode still writes standalone YAML; does not touch `~/.continue/config.yaml`
- [x] Full suite: 553 pass (was 539; +14)
- [x] Contradictions benchmark: 105/105