### PR TITLE
v0.12.6: Cline adapter (install-cline)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ packages = ["world_model_server"]
 "world_model_server/adapters/codex/hooks_snippet.toml" = "world_model_server/adapters/codex/hooks_snippet.toml"
 "world_model_server/adapters/openclaw/openclaw.json" = "world_model_server/adapters/openclaw/openclaw.json"
 "world_model_server/adapters/copilot/mcp.json" = "world_model_server/adapters/copilot/mcp.json"
+"world_model_server/adapters/cline/mcp.json" = "world_model_server/adapters/cline/mcp.json"
 "world_model_server/adapters/hermes/config-snippet.yaml" = "world_model_server/adapters/hermes/config-snippet.yaml"
 "world_model_server/hermes_memory_provider/__init__.py" = "world_model_server/hermes_memory_provider/__init__.py"
 "world_model_server/hermes_memory_provider/plugin.yaml" = "world_model_server/hermes_memory_provider/plugin.yaml"

--- a/tests/test_v0126_install_cline.py
+++ b/tests/test_v0126_install_cline.py
@@ -1,0 +1,238 @@
+"""
+v0.12.6: install-cline adapter.
+
+Registers world-model-mcp with Cline by merging into ~/.cline/mcp.json.
+Cline uses a top-level ``mcpServers`` mapping (same shape as Cursor /
+Claude Code), distinct from Copilot's ``servers`` and Continue's
+mcpServers-list. Users routinely have other MCP servers already
+registered via Cline's UI, so the installer merges rather than
+overwrites — same discipline as install-copilot.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from world_model_server.cli import install_cline_command
+
+
+REPO_ROOT = Path(__file__).parent.parent
+BUNDLED = REPO_ROOT / "world_model_server" / "adapters" / "cline" / "mcp.json"
+
+
+# ---------------------------------------------------------------------------
+# B: bundled adapter file sanity
+# ---------------------------------------------------------------------------
+
+
+def test_b1_bundled_adapter_exists():
+    assert BUNDLED.exists(), f"Bundled adapter missing: {BUNDLED}"
+
+
+def test_b1_bundled_adapter_uses_mcp_servers_key():
+    """Cline uses 'mcpServers' (mapping), NOT 'servers' like Copilot."""
+    data = json.loads(BUNDLED.read_text())
+    assert "mcpServers" in data
+    assert "servers" not in data, (
+        "'servers' is Copilot's key; Cline expects 'mcpServers'."
+    )
+
+
+def test_b1_bundled_adapter_registers_world_model():
+    data = json.loads(BUNDLED.read_text())
+    entry = data["mcpServers"]["world-model"]
+    assert entry["command"] == "python3"
+    assert entry["args"] == ["-m", "world_model_server.server"]
+    # Cline-specific Boolean fields defaulted safely
+    assert entry.get("disabled") is False
+    assert entry.get("autoApprove") == []
+
+
+# ---------------------------------------------------------------------------
+# I: installer behavior
+# ---------------------------------------------------------------------------
+
+
+def _run(tmp_path, *, force=False, dry_run=False, config_path=None):
+    if config_path is None:
+        config_path = str(tmp_path / "mcp.json")
+    args = SimpleNamespace(
+        config_path=config_path,
+        force=force,
+        dry_run=dry_run,
+    )
+    install_cline_command(args)
+
+
+def test_i1_fresh_install_creates_config(tmp_path):
+    cfg = tmp_path / "mcp.json"
+    _run(tmp_path, config_path=str(cfg))
+    assert cfg.exists()
+    data = json.loads(cfg.read_text())
+    assert "world-model" in data["mcpServers"]
+
+
+def test_i1_fresh_install_matches_bundled_template(tmp_path):
+    cfg = tmp_path / "mcp.json"
+    _run(tmp_path, config_path=str(cfg))
+    assert json.loads(cfg.read_text()) == json.loads(BUNDLED.read_text())
+
+
+def test_i2_merge_preserves_other_servers(tmp_path):
+    cfg = tmp_path / "mcp.json"
+    existing = {
+        "mcpServers": {
+            "sqlite": {
+                "command": "node",
+                "args": ["/path/to/sqlite/server.js"],
+                "disabled": False,
+                "autoApprove": ["query"],
+            },
+            "brave": {
+                "url": "https://example.com/mcp",
+                "headers": {"Authorization": "Bearer xxx"},
+            },
+        }
+    }
+    cfg.write_text(json.dumps(existing, indent=2))
+    _run(tmp_path, config_path=str(cfg))
+    data = json.loads(cfg.read_text())
+    assert set(data["mcpServers"].keys()) == {"sqlite", "brave", "world-model"}
+    assert data["mcpServers"]["sqlite"]["autoApprove"] == ["query"]
+    assert data["mcpServers"]["brave"]["headers"]["Authorization"] == "Bearer xxx"
+
+
+def test_i2_merge_preserves_non_mcp_servers_top_level_keys(tmp_path):
+    cfg = tmp_path / "mcp.json"
+    existing = {
+        "userSettings": {"theme": "dark"},
+        "mcpServers": {"sqlite": {"command": "node"}},
+    }
+    cfg.write_text(json.dumps(existing, indent=2))
+    _run(tmp_path, config_path=str(cfg))
+    data = json.loads(cfg.read_text())
+    assert data.get("userSettings") == {"theme": "dark"}
+
+
+def test_i3_existing_world_model_entry_skipped_without_force(tmp_path):
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text(json.dumps(
+        {"mcpServers": {"world-model": {"command": "user-custom"}}}, indent=2
+    ))
+    _run(tmp_path, config_path=str(cfg))
+    data = json.loads(cfg.read_text())
+    assert data["mcpServers"]["world-model"]["command"] == "user-custom"
+
+
+def test_i3_force_overwrites_world_model_only(tmp_path):
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text(json.dumps({
+        "mcpServers": {
+            "world-model": {"command": "user-custom"},
+            "sqlite": {"command": "node"},
+        }
+    }, indent=2))
+    _run(tmp_path, config_path=str(cfg), force=True)
+    data = json.loads(cfg.read_text())
+    bundled = json.loads(BUNDLED.read_text())
+    assert data["mcpServers"]["world-model"] == bundled["mcpServers"]["world-model"]
+    assert data["mcpServers"]["sqlite"] == {"command": "node"}
+
+
+def test_i4_file_without_mcp_servers_key_gets_it_added(tmp_path):
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text(json.dumps({"userSettings": {"theme": "dark"}}, indent=2))
+    _run(tmp_path, config_path=str(cfg))
+    data = json.loads(cfg.read_text())
+    assert "mcpServers" in data
+    assert "world-model" in data["mcpServers"]
+    assert data["userSettings"] == {"theme": "dark"}
+
+
+# ---------------------------------------------------------------------------
+# E: error paths
+# ---------------------------------------------------------------------------
+
+
+def test_e1_malformed_json_refused(tmp_path):
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text("{not-json}")
+    with pytest.raises(SystemExit):
+        _run(tmp_path, config_path=str(cfg))
+    assert cfg.read_text() == "{not-json}"
+
+
+def test_e2_top_level_array_refused(tmp_path):
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text("[]")
+    with pytest.raises(SystemExit):
+        _run(tmp_path, config_path=str(cfg))
+
+
+def test_e3_mcp_servers_not_object_refused(tmp_path):
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text('{"mcpServers": ["not-a-map"]}')
+    with pytest.raises(SystemExit):
+        _run(tmp_path, config_path=str(cfg))
+
+
+# ---------------------------------------------------------------------------
+# D: --dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_d1_dry_run_does_not_create_file(tmp_path):
+    cfg = tmp_path / "mcp.json"
+    _run(tmp_path, config_path=str(cfg), dry_run=True)
+    assert not cfg.exists()
+
+
+def test_d1_dry_run_does_not_modify_existing(tmp_path):
+    cfg = tmp_path / "mcp.json"
+    original = json.dumps({"mcpServers": {"sqlite": {"command": "node"}}}, indent=2)
+    cfg.write_text(original)
+    _run(tmp_path, config_path=str(cfg), dry_run=True)
+    assert cfg.read_text() == original
+
+
+# ---------------------------------------------------------------------------
+# C: CLI wiring
+# ---------------------------------------------------------------------------
+
+
+def test_c1_subcommand_registered_in_help():
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "--help"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    assert "install-cline" in result.stdout
+
+
+def test_c1_subcommand_dry_run_via_cli(tmp_path):
+    cfg = tmp_path / "mcp.json"
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "world_model_server.cli",
+            "install-cline",
+            "--config-path", str(cfg),
+            "--dry-run",
+        ],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    assert "world-model" in result.stdout
+    assert "mcpServers" in result.stdout
+    assert not cfg.exists()

--- a/world_model_server/adapters/cline/mcp.json
+++ b/world_model_server/adapters/cline/mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "world-model": {
+      "command": "python3",
+      "args": ["-m", "world_model_server.server"],
+      "env": {
+        "WORLD_MODEL_DB_PATH": ".claude/world-model"
+      },
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}

--- a/world_model_server/cli.py
+++ b/world_model_server/cli.py
@@ -1285,6 +1285,94 @@ def install_copilot_command(args):
     )
 
 
+def install_cline_command(args):
+    """Register world-model-mcp with Cline by merging into ~/.cline/mcp.json.
+
+    Cline's MCP config uses a top-level ``mcpServers`` mapping (same shape
+    as Cursor / Claude Code — distinct from Copilot's ``servers`` and
+    Continue's mcpServers-list). Users may already have entries in this
+    file from Cline's UI-driven server installer, so the installer merges
+    rather than overwrites.
+
+    Behavior:
+      absent file        -> write bundled template
+      no ours in file    -> add mcpServers.world-model, preserve rest
+      ours already there -> skip unless --force
+      --force            -> overwrite only mcpServers.world-model
+      malformed / wrong-shape JSON -> refuse, exit nonzero
+
+    Options:
+      --config-path PATH  override the default ~/.cline/mcp.json
+      --force             overwrite an existing mcpServers.world-model
+      --dry-run           print the merged JSON without writing
+    """
+    import json
+
+    config_path = Path(args.config_path).expanduser().resolve() if args.config_path else (
+        Path.home() / ".cline" / "mcp.json"
+    )
+
+    pkg_root = Path(__file__).parent
+    adapter_src = pkg_root / "adapters" / "cline" / "mcp.json"
+    if not adapter_src.exists():
+        console.print(f"[red]Missing bundled adapter file: {adapter_src}[/red]")
+        sys.exit(1)
+
+    bundled = json.loads(adapter_src.read_text())
+    our_entry = bundled["mcpServers"]["world-model"]
+
+    if config_path.exists():
+        try:
+            existing = json.loads(config_path.read_text())
+        except json.JSONDecodeError as e:
+            console.print(
+                f"[red]Refusing to touch malformed JSON at {config_path}: {e}[/red]\n"
+                "Fix the file by hand and re-run."
+            )
+            sys.exit(1)
+        if not isinstance(existing, dict):
+            console.print(
+                f"[red]Refusing to touch {config_path}: top-level value must be an object, "
+                f"got {type(existing).__name__}[/red]"
+            )
+            sys.exit(1)
+        servers = existing.get("mcpServers")
+        if servers is not None and not isinstance(servers, dict):
+            console.print(
+                f"[red]Refusing to touch {config_path}: 'mcpServers' must be an object, "
+                f"got {type(servers).__name__}[/red]"
+            )
+            sys.exit(1)
+        if servers is None:
+            existing["mcpServers"] = {}
+            servers = existing["mcpServers"]
+        if "world-model" in servers and not args.force:
+            console.print(
+                f"[yellow]world-model already registered in {config_path}[/yellow]\n"
+                "Use --force to overwrite that entry (other servers preserved)."
+            )
+            return
+        servers["world-model"] = our_entry
+        merged = existing
+    else:
+        merged = bundled
+
+    if args.dry_run:
+        console.print(f"[bold]Would write:[/bold] {config_path}")
+        console.print(json.dumps(merged, indent=2))
+        return
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(merged, indent=2) + "\n")
+
+    console.print(f"[green]Cline adapter installed[/green]")
+    console.print(f"  + {config_path}")
+    console.print(
+        "\nNext: reload the Cline extension (VS Code: Cmd/Ctrl+Shift+P -> "
+        "'Cline: Restart Cline'). world-model will appear in Cline's MCP panel."
+    )
+
+
 def install_pi_command(args):
     """Copy the pi adapter (index.ts, package.json) into ./adapters/world-model-pi/.
 
@@ -1606,6 +1694,27 @@ def main():
         help="Print the merged JSON that would be written; don't touch disk",
     )
     copilot_parser.set_defaults(func=install_copilot_command)
+
+    cline_parser = subparsers.add_parser(
+        "install-cline",
+        help=(
+            "Register world-model with Cline by merging into ~/.cline/mcp.json "
+            "(preserves other servers)"
+        ),
+    )
+    cline_parser.add_argument(
+        "--config-path", type=str, default=None,
+        help="Override the default ~/.cline/mcp.json path",
+    )
+    cline_parser.add_argument(
+        "--force", action="store_true",
+        help="Overwrite an existing 'mcpServers.world-model' entry",
+    )
+    cline_parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print the merged JSON that would be written; don't touch disk",
+    )
+    cline_parser.set_defaults(func=install_cline_command)
 
     pi_parser = subparsers.add_parser(
         "install-pi", help="Install the pi adapter to ./adapters/world-model-pi/"


### PR DESCRIPTION
## Summary

Registers world-model-mcp with Cline (VS Code / JetBrains) by merging into `~/.cline/mcp.json`. Cline uses a top-level `mcpServers` mapping — same shape as Cursor / Claude Code, distinct from Copilot's `servers` and Continue's mcpServers-list.

## Merge semantics

Identical to install-copilot:

| State | Behavior |
| --- | --- |
| File absent | Write bundled template |
| No `world-model` | Add, preserve rest |
| Present | Skip unless `--force` |
| `--force` | Overwrite only `mcpServers.world-model` |
| Malformed / wrong-shape JSON | Refuse, exit nonzero, leave file untouched |

`--dry-run` prints without writing. `--config-path` overrides `~/.cline/mcp.json` for tests / non-default installs.

## Cline-specific defaults

Bundled template includes `"disabled": false` and `"autoApprove": []`, matching Cline's config shape. Users can flip these via Cline's UI; `--force` only rewrites `world-model` (never rewrites unrelated servers) so it's safe to re-run.

## Packaging

`adapters/cline/mcp.json` added to `[tool.hatch.build.targets.wheel.force-include]`.

## Test plan

- [x] 17 new tests in `tests/test_v0126_install_cline.py` mirroring install-copilot structure
- [x] B1: bundled uses `mcpServers` (not `servers`), registers world-model with Cline defaults
- [x] I1-I4: fresh install, merge preserves other servers, merge preserves non-mcpServers keys, skip-without-force, `--force` overwrites only world-model, file-without-mcpServers gets it added
- [x] E1-E3: malformed JSON refused, top-level array refused, non-object mcpServers refused
- [x] D1: `--dry-run` no-op
- [x] C1: subcommand in `--help`; CLI `--dry-run` works end-to-end via subprocess
- [x] Full suite: 570 pass (was 553; +17)
- [x] Contradictions benchmark: 105/105