### PR TITLE
v0.12.7: Windsurf adapter (install-windsurf)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ packages = ["world_model_server"]
 "world_model_server/adapters/openclaw/openclaw.json" = "world_model_server/adapters/openclaw/openclaw.json"
 "world_model_server/adapters/copilot/mcp.json" = "world_model_server/adapters/copilot/mcp.json"
 "world_model_server/adapters/cline/mcp.json" = "world_model_server/adapters/cline/mcp.json"
+"world_model_server/adapters/windsurf/mcp_config.json" = "world_model_server/adapters/windsurf/mcp_config.json"
 "world_model_server/adapters/hermes/config-snippet.yaml" = "world_model_server/adapters/hermes/config-snippet.yaml"
 "world_model_server/hermes_memory_provider/__init__.py" = "world_model_server/hermes_memory_provider/__init__.py"
 "world_model_server/hermes_memory_provider/plugin.yaml" = "world_model_server/hermes_memory_provider/plugin.yaml"

--- a/tests/test_v0127_install_windsurf.py
+++ b/tests/test_v0127_install_windsurf.py
@@ -1,0 +1,227 @@
+"""
+v0.12.7: install-windsurf adapter.
+
+Registers world-model-mcp with Windsurf's Cascade agent by merging into
+~/.codeium/windsurf/mcp_config.json. Windsurf uses the top-level
+``mcpServers`` mapping — same shape as Cline / Cursor / Claude Code, so
+the merge logic is behaviorally identical to install-cline. The only
+real difference is the default config path.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from world_model_server.cli import install_windsurf_command
+
+
+REPO_ROOT = Path(__file__).parent.parent
+BUNDLED = REPO_ROOT / "world_model_server" / "adapters" / "windsurf" / "mcp_config.json"
+
+
+# ---------------------------------------------------------------------------
+# B: bundled adapter file sanity
+# ---------------------------------------------------------------------------
+
+
+def test_b1_bundled_adapter_exists():
+    assert BUNDLED.exists(), f"Bundled adapter missing: {BUNDLED}"
+
+
+def test_b1_bundled_adapter_uses_mcp_servers_key():
+    """Windsurf uses 'mcpServers' (mapping), same shape as Cline."""
+    data = json.loads(BUNDLED.read_text())
+    assert "mcpServers" in data
+    assert "servers" not in data
+
+
+def test_b1_bundled_adapter_registers_world_model():
+    data = json.loads(BUNDLED.read_text())
+    entry = data["mcpServers"]["world-model"]
+    assert entry["command"] == "python3"
+    assert entry["args"] == ["-m", "world_model_server.server"]
+    assert entry["env"]["WORLD_MODEL_DB_PATH"] == ".claude/world-model"
+
+
+# ---------------------------------------------------------------------------
+# I: installer behavior
+# ---------------------------------------------------------------------------
+
+
+def _run(tmp_path, *, force=False, dry_run=False, config_path=None):
+    if config_path is None:
+        config_path = str(tmp_path / "mcp_config.json")
+    args = SimpleNamespace(
+        config_path=config_path,
+        force=force,
+        dry_run=dry_run,
+    )
+    install_windsurf_command(args)
+
+
+def test_i1_fresh_install_creates_config(tmp_path):
+    cfg = tmp_path / "mcp_config.json"
+    _run(tmp_path, config_path=str(cfg))
+    assert cfg.exists()
+    data = json.loads(cfg.read_text())
+    assert "world-model" in data["mcpServers"]
+
+
+def test_i1_fresh_install_matches_bundled(tmp_path):
+    cfg = tmp_path / "mcp_config.json"
+    _run(tmp_path, config_path=str(cfg))
+    assert json.loads(cfg.read_text()) == json.loads(BUNDLED.read_text())
+
+
+def test_i2_merge_preserves_other_servers(tmp_path):
+    cfg = tmp_path / "mcp_config.json"
+    existing = {
+        "mcpServers": {
+            "github": {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-github"],
+                "env": {"GITHUB_PERSONAL_ACCESS_TOKEN": "token123"},
+            }
+        }
+    }
+    cfg.write_text(json.dumps(existing, indent=2))
+    _run(tmp_path, config_path=str(cfg))
+    data = json.loads(cfg.read_text())
+    assert "github" in data["mcpServers"], "github MCP entry got clobbered"
+    assert data["mcpServers"]["github"]["env"]["GITHUB_PERSONAL_ACCESS_TOKEN"] == "token123"
+    assert "world-model" in data["mcpServers"]
+
+
+def test_i2_merge_preserves_top_level_non_mcp_servers_keys(tmp_path):
+    cfg = tmp_path / "mcp_config.json"
+    cfg.write_text(json.dumps({
+        "customSetting": {"foo": "bar"},
+        "mcpServers": {"github": {"command": "npx"}},
+    }, indent=2))
+    _run(tmp_path, config_path=str(cfg))
+    data = json.loads(cfg.read_text())
+    assert data.get("customSetting") == {"foo": "bar"}
+
+
+def test_i3_existing_world_model_entry_skipped_without_force(tmp_path):
+    cfg = tmp_path / "mcp_config.json"
+    cfg.write_text(json.dumps(
+        {"mcpServers": {"world-model": {"command": "user-custom"}}}, indent=2
+    ))
+    _run(tmp_path, config_path=str(cfg))
+    data = json.loads(cfg.read_text())
+    assert data["mcpServers"]["world-model"]["command"] == "user-custom"
+
+
+def test_i3_force_overwrites_world_model_only(tmp_path):
+    cfg = tmp_path / "mcp_config.json"
+    cfg.write_text(json.dumps({
+        "mcpServers": {
+            "world-model": {"command": "user-custom"},
+            "github": {"command": "npx"},
+        }
+    }, indent=2))
+    _run(tmp_path, config_path=str(cfg), force=True)
+    data = json.loads(cfg.read_text())
+    bundled = json.loads(BUNDLED.read_text())
+    assert data["mcpServers"]["world-model"] == bundled["mcpServers"]["world-model"]
+    assert data["mcpServers"]["github"] == {"command": "npx"}
+
+
+def test_i4_file_without_mcp_servers_key_gets_it_added(tmp_path):
+    cfg = tmp_path / "mcp_config.json"
+    cfg.write_text(json.dumps({"customSetting": {"foo": "bar"}}, indent=2))
+    _run(tmp_path, config_path=str(cfg))
+    data = json.loads(cfg.read_text())
+    assert "mcpServers" in data
+    assert "world-model" in data["mcpServers"]
+    assert data["customSetting"] == {"foo": "bar"}
+
+
+# ---------------------------------------------------------------------------
+# E: error paths
+# ---------------------------------------------------------------------------
+
+
+def test_e1_malformed_json_refused(tmp_path):
+    cfg = tmp_path / "mcp_config.json"
+    cfg.write_text("{not-json}")
+    with pytest.raises(SystemExit):
+        _run(tmp_path, config_path=str(cfg))
+    assert cfg.read_text() == "{not-json}"
+
+
+def test_e2_top_level_array_refused(tmp_path):
+    cfg = tmp_path / "mcp_config.json"
+    cfg.write_text("[]")
+    with pytest.raises(SystemExit):
+        _run(tmp_path, config_path=str(cfg))
+
+
+def test_e3_mcp_servers_not_object_refused(tmp_path):
+    cfg = tmp_path / "mcp_config.json"
+    cfg.write_text('{"mcpServers": ["not-a-map"]}')
+    with pytest.raises(SystemExit):
+        _run(tmp_path, config_path=str(cfg))
+
+
+# ---------------------------------------------------------------------------
+# D: --dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_d1_dry_run_does_not_create_file(tmp_path):
+    cfg = tmp_path / "mcp_config.json"
+    _run(tmp_path, config_path=str(cfg), dry_run=True)
+    assert not cfg.exists()
+
+
+def test_d1_dry_run_does_not_modify_existing(tmp_path):
+    cfg = tmp_path / "mcp_config.json"
+    original = json.dumps({"mcpServers": {"github": {"command": "npx"}}}, indent=2)
+    cfg.write_text(original)
+    _run(tmp_path, config_path=str(cfg), dry_run=True)
+    assert cfg.read_text() == original
+
+
+# ---------------------------------------------------------------------------
+# C: CLI wiring
+# ---------------------------------------------------------------------------
+
+
+def test_c1_subcommand_registered_in_help():
+    result = subprocess.run(
+        [sys.executable, "-m", "world_model_server.cli", "--help"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    assert "install-windsurf" in result.stdout
+
+
+def test_c1_subcommand_dry_run_via_cli(tmp_path):
+    cfg = tmp_path / "mcp_config.json"
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "world_model_server.cli",
+            "install-windsurf",
+            "--config-path", str(cfg),
+            "--dry-run",
+        ],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    assert "world-model" in result.stdout
+    assert "mcpServers" in result.stdout
+    assert not cfg.exists()

--- a/world_model_server/adapters/windsurf/mcp_config.json
+++ b/world_model_server/adapters/windsurf/mcp_config.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "world-model": {
+      "command": "python3",
+      "args": ["-m", "world_model_server.server"],
+      "env": {
+        "WORLD_MODEL_DB_PATH": ".claude/world-model"
+      }
+    }
+  }
+}

--- a/world_model_server/cli.py
+++ b/world_model_server/cli.py
@@ -1373,6 +1373,94 @@ def install_cline_command(args):
     )
 
 
+def install_windsurf_command(args):
+    """Register world-model-mcp with Windsurf's Cascade agent by merging
+    into ~/.codeium/windsurf/mcp_config.json.
+
+    Windsurf uses a top-level ``mcpServers`` mapping — same shape as
+    Cline / Cursor / Claude Code. The merge behavior is identical to
+    install-cline; the only real difference is the default config path.
+
+    Behavior:
+      absent file        -> write bundled template
+      no ours in file    -> add mcpServers.world-model, preserve rest
+      ours already there -> skip unless --force
+      --force            -> overwrite only mcpServers.world-model
+      malformed / wrong-shape JSON -> refuse, exit nonzero
+
+    Options:
+      --config-path PATH  override ~/.codeium/windsurf/mcp_config.json
+      --force             overwrite an existing mcpServers.world-model
+      --dry-run           print the merged JSON without writing
+    """
+    import json
+
+    config_path = Path(args.config_path).expanduser().resolve() if args.config_path else (
+        Path.home() / ".codeium" / "windsurf" / "mcp_config.json"
+    )
+
+    pkg_root = Path(__file__).parent
+    adapter_src = pkg_root / "adapters" / "windsurf" / "mcp_config.json"
+    if not adapter_src.exists():
+        console.print(f"[red]Missing bundled adapter file: {adapter_src}[/red]")
+        sys.exit(1)
+
+    bundled = json.loads(adapter_src.read_text())
+    our_entry = bundled["mcpServers"]["world-model"]
+
+    if config_path.exists():
+        try:
+            existing = json.loads(config_path.read_text())
+        except json.JSONDecodeError as e:
+            console.print(
+                f"[red]Refusing to touch malformed JSON at {config_path}: {e}[/red]\n"
+                "Fix the file by hand and re-run."
+            )
+            sys.exit(1)
+        if not isinstance(existing, dict):
+            console.print(
+                f"[red]Refusing to touch {config_path}: top-level value must be an object, "
+                f"got {type(existing).__name__}[/red]"
+            )
+            sys.exit(1)
+        servers = existing.get("mcpServers")
+        if servers is not None and not isinstance(servers, dict):
+            console.print(
+                f"[red]Refusing to touch {config_path}: 'mcpServers' must be an object, "
+                f"got {type(servers).__name__}[/red]"
+            )
+            sys.exit(1)
+        if servers is None:
+            existing["mcpServers"] = {}
+            servers = existing["mcpServers"]
+        if "world-model" in servers and not args.force:
+            console.print(
+                f"[yellow]world-model already registered in {config_path}[/yellow]\n"
+                "Use --force to overwrite that entry (other servers preserved)."
+            )
+            return
+        servers["world-model"] = our_entry
+        merged = existing
+    else:
+        merged = bundled
+
+    if args.dry_run:
+        console.print(f"[bold]Would write:[/bold] {config_path}")
+        console.print(json.dumps(merged, indent=2))
+        return
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(merged, indent=2) + "\n")
+
+    console.print(f"[green]Windsurf adapter installed[/green]")
+    console.print(f"  + {config_path}")
+    console.print(
+        "\nNext: from Windsurf run 'Windsurf: Refresh MCP Servers' via the "
+        "command palette, or restart Windsurf. world-model will appear in "
+        "the MCP servers panel."
+    )
+
+
 def install_pi_command(args):
     """Copy the pi adapter (index.ts, package.json) into ./adapters/world-model-pi/.
 
@@ -1715,6 +1803,27 @@ def main():
         help="Print the merged JSON that would be written; don't touch disk",
     )
     cline_parser.set_defaults(func=install_cline_command)
+
+    windsurf_parser = subparsers.add_parser(
+        "install-windsurf",
+        help=(
+            "Register world-model with Windsurf's Cascade agent by merging "
+            "into ~/.codeium/windsurf/mcp_config.json (preserves other servers)"
+        ),
+    )
+    windsurf_parser.add_argument(
+        "--config-path", type=str, default=None,
+        help="Override the default ~/.codeium/windsurf/mcp_config.json path",
+    )
+    windsurf_parser.add_argument(
+        "--force", action="store_true",
+        help="Overwrite an existing 'mcpServers.world-model' entry",
+    )
+    windsurf_parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print the merged JSON that would be written; don't touch disk",
+    )
+    windsurf_parser.set_defaults(func=install_windsurf_command)
 
     pi_parser = subparsers.add_parser(
         "install-pi", help="Install the pi adapter to ./adapters/world-model-pi/"


### PR DESCRIPTION
## Summary

Registers world-model-mcp with Windsurf's Cascade agent by merging into `~/.codeium/windsurf/mcp_config.json`. Windsurf uses the top-level `mcpServers`-mapping shape — same as Cline / Cursor / Claude Code. Merge behavior is behaviorally identical to install-cline; only the default path differs.

## Merge semantics

| State | Behavior |
| --- | --- |
| File absent | Write bundled template |
| No `world-model` | Add, preserve rest |
| Present | Skip unless `--force` |
| `--force` | Overwrite only `mcpServers.world-model` |
| Malformed / wrong-shape JSON | Refuse, exit nonzero |

`--dry-run` prints without writing. `--config-path` overrides default.

## Not refactored yet

Deliberately kept the merge logic duplicated across the three JSON-merge adapters (copilot, cline, windsurf) rather than extracting a shared helper. Each landed and passed its own regression suite; folding them together now is scope creep with a real risk of subtly changing tested behavior. If a fourth mcpServers-mapping adapter arrives (Trae is in the wings), that is the moment to extract.

## Test plan

- [x] 17 new tests in `tests/test_v0127_install_windsurf.py` mirroring the install-cline suite
- [x] B1: bundled uses `mcpServers`, registers world-model with expected shape
- [x] I1-I4: fresh install, merge preservation, skip / force, file-without-mcpServers
- [x] E1-E3: malformed / wrong-shape refusal, leaves file untouched
- [x] D1: `--dry-run` no-op
- [x] C1: subcommand in `--help`; CLI `--dry-run` works end-to-end via subprocess
- [x] Full suite: 587 pass (was 570; +17)
- [x] Contradictions benchmark: 105/105