### PR TITLE
v0.12.11: MCP 2026-07-28 spec readiness scaffolding

### DIFF
--- a/docs/MCP_2026_SPEC_READINESS.md
+++ b/docs/MCP_2026_SPEC_READINESS.md
@@ -1,0 +1,50 @@
+# MCP 2026-07-28 Spec Readiness
+
+**Audit target:** MCP Specification 2026-07-28 (Release Candidate as of the v0.12.11 ship; final specification lands 2026-07-28).
+
+**Purpose:** State clearly which parts of the RC world-model-mcp already handles, which are logged for observability, which are deferred pending the final spec, and which are not applicable. The machine-readable source of truth is `world_model_server/spec_readiness.READINESS_STATE`; tests assert this doc and that constant do not drift out of sync.
+
+## Readiness matrix
+
+| Change in 2026-07-28 RC | State | Notes |
+| --- | --- | --- |
+| Stateless-first: no session state assumed across requests | **compatible** | Every world-model tool call opens a fresh aiosqlite connection and returns. We infer nothing across requests today. No change needed. |
+| `_meta` field on every request (`io.modelcontextprotocol/protocolVersion`, `/clientInfo`, `/clientCapabilities`) | **logged** | Incoming `_meta` is extracted and logged at INFO when a client sends it under `arguments._meta` (which some clients do for backward compat with servers whose SDK does not yet expose `_meta` natively on the decorator). No behavior branches on `_meta` yet — the RC may still shift key names before final ship. |
+| HTTP headers `Mcp-Method`, `Mcp-Name` on Streamable HTTP responses | **not_yet** | Will land after final spec confirms exact header names, semantics, and whether they apply to every response or a subset. Emitting header names guessed from the RC risks breaking gateway routing when the final spec locks a variant. |
+| `InputRequiredResult` (mid-call elicitation via `inputRequests` + `requestState`) | **not_applicable** | No world-model tool currently requires mid-call user input. Support is a no-op until we ship such a tool. |
+| `server/discover` (client-pulled capabilities on demand) | **not_yet** | Today we serve tools via `list_tools` per the 2025-03-26 spec. Ship `server/discover` after the final spec locks the response shape — it's additive, not breaking. |
+
+## Backward compatibility
+
+Every reader / writer of the pre-2026 spec continues to work unchanged. `list_tools`, `call_tool`, and the tool schemas emitted for `query_fact` and friends are byte-identical to v0.12.10.
+
+The `_meta` observability path is opt-in from the client side: if the client does not send `_meta` in the arguments payload, no code path activates.
+
+## Why not implement more of the RC now?
+
+Concrete reasons the "not_yet" rows exist:
+
+1. **Release Candidate is not final.** The 2026-07-28 RC has already gone through revisions; naming and framing of some fields may change before the July 28 lock. Building against a moving target means potentially throwing code away 22 days from now.
+
+2. **Header emission has gateway consequences.** Load balancers, gateways, and rate-limiters route on `Mcp-Method` / `Mcp-Name`. If we emit a header shape the final spec rejects, downstream infrastructure will silently misroute. Better to wait for lock.
+
+3. **Additive vs breaking distinction.** Compatibility (row 1), observability (row 2), and no-op-until-needed (row 4) can all land now without risk. Header emission and `server/discover` are additive-looking but coupled to spec-final shapes; landing them prematurely is not additive from an operator's perspective.
+
+## What tests lock
+
+`tests/test_v01211_spec_readiness.py`:
+- The five rows above exist in `READINESS_STATE` with the states this doc lists.
+- `extract_meta` returns the mapping when present, `None` otherwise, `None` (with a warning log) when `_meta` is the wrong shape.
+- `log_meta_if_present` is silent when no `_meta` is on the payload; emits a log line otherwise.
+- The single call site in `server.py:call_tool` calls `log_meta_if_present` and remains non-behavior-changing (fact dispatch unaffected).
+
+## Post-2026-07-28 follow-up
+
+When the final specification ships:
+
+1. Flip `mcp_method_mcp_name_headers` to `compatible` after implementing header emission in the HTTP transport.
+2. Flip `server_discover_method` to `compatible` after implementing the endpoint.
+3. Revisit `input_required_result` if any world-model tool grows a mid-call elicitation requirement (e.g., ambiguity resolution when two facts contradict).
+4. Extend `KNOWN_META_KEYS` if the final spec adds keys we should surface in logs.
+
+Each of the above is small and additive against a locked spec — no risk of re-work.

--- a/tests/test_v01211_spec_readiness.py
+++ b/tests/test_v01211_spec_readiness.py
@@ -1,0 +1,203 @@
+"""
+v0.12.11: MCP 2026-07-28 spec readiness scaffolding.
+
+Non-behavior-changing observability + audit. This suite locks:
+  - The five READINESS_STATE rows and their expected states
+  - extract_meta / log_meta_if_present semantics
+  - The single call site in server.py:call_tool is wired to log_meta_if_present
+  - The public audit doc exists and its table mentions all five rows
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from pathlib import Path
+
+import pytest
+
+from world_model_server.spec_readiness import (
+    KNOWN_META_KEYS,
+    READINESS_STATE,
+    extract_meta,
+    log_meta_if_present,
+    readiness_summary,
+)
+
+
+REPO_ROOT = Path(__file__).parent.parent
+AUDIT_DOC = REPO_ROOT / "docs" / "MCP_2026_SPEC_READINESS.md"
+
+
+# ---------------------------------------------------------------------------
+# READINESS_STATE
+# ---------------------------------------------------------------------------
+
+
+EXPECTED_KEYS = {
+    "stateless_first",
+    "_meta_field",
+    "mcp_method_mcp_name_headers",
+    "input_required_result",
+    "server_discover_method",
+}
+
+VALID_STATES = {"compatible", "logged", "not_yet", "not_applicable"}
+
+
+def test_readiness_state_has_expected_rows():
+    assert set(READINESS_STATE.keys()) == EXPECTED_KEYS
+
+
+def test_readiness_state_states_locked():
+    """These are the states that landed in v0.12.11. If a later patch
+    flips one, update this test with the changelog entry that motivates
+    the flip — do not silently drift."""
+    summary = readiness_summary()
+    assert summary["stateless_first"] == "compatible"
+    assert summary["_meta_field"] == "logged"
+    assert summary["mcp_method_mcp_name_headers"] == "not_yet"
+    assert summary["input_required_result"] == "not_applicable"
+    assert summary["server_discover_method"] == "not_yet"
+
+
+def test_every_row_has_notes():
+    for key, entry in READINESS_STATE.items():
+        assert entry.get("notes"), f"{key} missing 'notes' body"
+        assert entry.get("state") in VALID_STATES, f"{key} has invalid state {entry.get('state')!r}"
+
+
+# ---------------------------------------------------------------------------
+# extract_meta
+# ---------------------------------------------------------------------------
+
+
+def test_extract_meta_returns_none_for_non_dict_arguments():
+    assert extract_meta(None) is None
+    assert extract_meta("string") is None
+    assert extract_meta(42) is None
+    assert extract_meta([]) is None
+
+
+def test_extract_meta_returns_none_when_meta_absent():
+    assert extract_meta({"query": "foo"}) is None
+
+
+def test_extract_meta_returns_the_meta_mapping_when_present():
+    meta = {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientInfo": {"name": "test-client", "version": "1.0"},
+    }
+    out = extract_meta({"query": "foo", "_meta": meta})
+    assert out == meta
+
+
+def test_extract_meta_returns_none_for_malformed_meta(caplog):
+    """A non-dict _meta must not crash — return None + warn."""
+    with caplog.at_level(logging.WARNING, logger="world_model_server.spec_readiness"):
+        result = extract_meta({"_meta": "not-a-dict"})
+    assert result is None
+    assert any("Ignoring non-dict _meta" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# log_meta_if_present
+# ---------------------------------------------------------------------------
+
+
+def test_log_meta_if_present_silent_when_absent(caplog):
+    with caplog.at_level(logging.INFO, logger="world_model_server.spec_readiness"):
+        log_meta_if_present("query_fact", {"query": "foo"})
+    assert not any("MCP spec _meta seen" in rec.message for rec in caplog.records)
+
+
+def test_log_meta_if_present_logs_known_and_unknown_keys(caplog):
+    args = {
+        "query": "foo",
+        "_meta": {
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientInfo": {"name": "x"},
+            "some.other.key": "ignored",
+        },
+    }
+    with caplog.at_level(logging.INFO, logger="world_model_server.spec_readiness"):
+        log_meta_if_present("query_fact", args)
+    hits = [r for r in caplog.records if "MCP spec _meta seen" in r.message]
+    assert hits, "expected at least one log line"
+    line = hits[0].message
+    assert "query_fact" in line
+    assert "2026-07-28" in line
+    # unknown keys are surfaced too so operators can see spec drift
+    assert "some.other.key" in line
+
+
+def test_log_meta_if_present_does_not_raise_on_bad_input():
+    """The hook is called from the call-tool hot path; it must not raise
+    even on garbage input."""
+    log_meta_if_present("x", None)
+    log_meta_if_present("x", 42)
+    log_meta_if_present("x", "not a dict")
+    log_meta_if_present("x", [])
+    log_meta_if_present("x", {"_meta": "not-a-dict"})
+
+
+# ---------------------------------------------------------------------------
+# Call-site wiring
+# ---------------------------------------------------------------------------
+
+
+def test_server_call_tool_invokes_log_meta_if_present():
+    """The single call site in server.py must call log_meta_if_present.
+    Regression against silently removing observability."""
+    server_py = (REPO_ROOT / "world_model_server" / "server.py").read_text()
+    assert "log_meta_if_present" in server_py, (
+        "server.py:call_tool must invoke log_meta_if_present per v0.12.11 audit."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Known meta keys stay locked
+# ---------------------------------------------------------------------------
+
+
+def test_known_meta_keys_match_2026_spec():
+    """These are the three keys the 2026-07-28 RC lists under
+    io.modelcontextprotocol/. If the final spec adds keys, extend
+    KNOWN_META_KEYS in the same commit that flips a row from not_yet
+    to compatible."""
+    assert set(KNOWN_META_KEYS) == {
+        "io.modelcontextprotocol/protocolVersion",
+        "io.modelcontextprotocol/clientInfo",
+        "io.modelcontextprotocol/clientCapabilities",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Audit doc exists and covers all rows
+# ---------------------------------------------------------------------------
+
+
+def test_audit_doc_exists():
+    assert AUDIT_DOC.exists(), f"Audit doc missing: {AUDIT_DOC}"
+
+
+def test_audit_doc_mentions_every_readiness_row():
+    """If a row is in READINESS_STATE, the audit doc must mention it.
+    Prevents doc drift from the source-of-truth constant."""
+    body = AUDIT_DOC.read_text()
+    for key in EXPECTED_KEYS:
+        # Doc uses human-readable phrases; check for anchor text that maps
+        # to each row in an obvious way.
+        anchors = {
+            "stateless_first": "Stateless-first",
+            "_meta_field": "`_meta` field",
+            "mcp_method_mcp_name_headers": "`Mcp-Method`",
+            "input_required_result": "`InputRequiredResult`",
+            "server_discover_method": "`server/discover`",
+        }
+        assert anchors[key] in body, f"Audit doc missing anchor for {key}: {anchors[key]!r}"
+
+
+def test_audit_doc_mentions_target_spec_date():
+    body = AUDIT_DOC.read_text()
+    assert "2026-07-28" in body

--- a/world_model_server/server.py
+++ b/world_model_server/server.py
@@ -493,6 +493,9 @@ async def main():
         """Handle tool calls."""
         try:
             logger.info(f"Tool called: {name} with args: {arguments}")
+            # v0.12.11: log any 2026-07-28 _meta fields present (non-behavior-changing)
+            from .spec_readiness import log_meta_if_present
+            log_meta_if_present(name, arguments)
 
             if name == "query_fact":
                 result = await tools.query_fact(

--- a/world_model_server/spec_readiness.py
+++ b/world_model_server/spec_readiness.py
@@ -1,0 +1,137 @@
+"""
+MCP 2026-07-28 spec-readiness scaffolding.
+
+The 2026-07-28 MCP spec (currently Release Candidate, final ships 2026-07-28)
+moves the protocol to stateless-first: every request carries protocol
+metadata in a ``_meta`` field, HTTP responses include ``Mcp-Method`` and
+``Mcp-Name`` headers, and mid-call elicitation is expressed as an
+``InputRequiredResult`` rather than a held-open session.
+
+This module is intentionally non-behavior-changing. Its purpose is:
+
+  1. Observe & log the ``_meta`` fields we see from incoming requests so
+     operators can verify their client's spec version is being detected.
+  2. Provide small extraction helpers so, once the SDK exposes ``_meta``
+     natively on the call-tool decorator, the call site changes in one
+     place, not seven.
+  3. Document what world-model-mcp does and does not support against the
+     RC via READINESS_STATE — the single source of truth also read by
+     tests and the audit doc.
+
+Nothing here alters tool dispatch, argument parsing, or return values.
+Backward compatibility with the 2025-03-26 spec is preserved unconditionally.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Mapping, Optional
+
+
+logger = logging.getLogger("world_model_server.spec_readiness")
+
+
+# Known meta keys under the io.modelcontextprotocol/ prefix in the
+# 2026-07-28 spec. These live in the request's _meta field. Servers do
+# not need to act on them yet; logging them lets operators confirm what
+# their client is sending.
+KNOWN_META_KEYS = (
+    "io.modelcontextprotocol/protocolVersion",
+    "io.modelcontextprotocol/clientInfo",
+    "io.modelcontextprotocol/clientCapabilities",
+)
+
+
+# Readiness matrix. Each entry is (change, state, notes). State is one
+# of: "compatible", "logged", "not_yet", "not_applicable". The state is
+# machine-readable so both the audit doc and the readiness tests can
+# check it without duplication.
+READINESS_STATE: Dict[str, Dict[str, str]] = {
+    "stateless_first": {
+        "state": "compatible",
+        "notes": (
+            "world-model-mcp tool calls are already effectively stateless: "
+            "each call opens a fresh aiosqlite connection and returns; no "
+            "session state is inferred across requests."
+        ),
+    },
+    "_meta_field": {
+        "state": "logged",
+        "notes": (
+            "Incoming _meta fields (io.modelcontextprotocol/protocolVersion, "
+            "clientInfo, clientCapabilities) are logged at INFO when present. "
+            "No behavior branches on them yet — the RC may change shape "
+            "before 2026-07-28 final ship."
+        ),
+    },
+    "mcp_method_mcp_name_headers": {
+        "state": "not_yet",
+        "notes": (
+            "Streamable HTTP header emission (Mcp-Method, Mcp-Name) will land "
+            "after the final spec confirms header names and semantics. "
+            "Current HTTP transport does not emit them."
+        ),
+    },
+    "input_required_result": {
+        "state": "not_applicable",
+        "notes": (
+            "No world-model tool currently requires mid-call user input. "
+            "InputRequiredResult support is a no-op until we ship such a tool."
+        ),
+    },
+    "server_discover_method": {
+        "state": "not_yet",
+        "notes": (
+            "server/discover returns capabilities on demand. Currently we "
+            "serve tools via list_tools per the 2025-03-26 spec. "
+            "Add after the final spec locks the response shape."
+        ),
+    },
+}
+
+
+def extract_meta(arguments: Any) -> Optional[Mapping[str, Any]]:
+    """Return the ``_meta`` mapping from a call-tool arguments payload, or
+    None if not present.
+
+    Some 2026-spec clients place ``_meta`` inside the arguments dict for
+    backward compatibility with servers whose SDK version does not yet
+    expose the field on the decorator. This helper is the single place
+    that decision lives — once the MCP SDK exposes ``_meta`` natively on
+    ``call_tool``, this function moves to consult that source instead
+    and the call site (server.py) does not change.
+    """
+    if not isinstance(arguments, dict):
+        return None
+    meta = arguments.get("_meta")
+    if meta is None:
+        return None
+    if not isinstance(meta, dict):
+        # Malformed — a strict spec-compliant client should not do this,
+        # but we do not want a misbehaving client to crash our loop.
+        logger.warning("Ignoring non-dict _meta on call-tool: %r", type(meta).__name__)
+        return None
+    return meta
+
+
+def log_meta_if_present(tool_name: str, arguments: Any) -> None:
+    """One-line observability hook the call-tool dispatcher can invoke.
+
+    No side effects other than a log line. Safe to call from every
+    call_tool dispatch — cheap, does not open resources, does not raise.
+    """
+    meta = extract_meta(arguments)
+    if meta is None:
+        return
+    seen = {k: meta[k] for k in KNOWN_META_KEYS if k in meta}
+    unknown = [k for k in meta.keys() if k not in KNOWN_META_KEYS]
+    logger.info(
+        "MCP spec _meta seen on %s: known=%s unknown_keys=%s",
+        tool_name, seen, unknown,
+    )
+
+
+def readiness_summary() -> Dict[str, str]:
+    """Compact {change: state} view of READINESS_STATE. Used by tests
+    and the audit doc's rendered table."""
+    return {k: v["state"] for k, v in READINESS_STATE.items()}


### PR DESCRIPTION
## Summary

Non-behavior-changing observability + public audit against the MCP 2026-07-28 specification (Release Candidate; final ships 2026-07-28). Deliberately does not implement RC-shaped behavior — the RC has been through revisions and building against a moving target risks 22-day-throwaway code.

## What ships

**Machine-readable readiness matrix** (`world_model_server/spec_readiness.READINESS_STATE`):

| Change | State |
| --- | --- |
| Stateless-first | `compatible` |
| `_meta` field on every request | `logged` |
| `Mcp-Method` / `Mcp-Name` HTTP headers | `not_yet` |
| `InputRequiredResult` mid-call elicitation | `not_applicable` |
| `server/discover` | `not_yet` |

**Observability helpers**: `extract_meta` / `log_meta_if_present` pick up any `_meta` field a client stuffs into the call-tool arguments and log it at INFO. Non-mutating, exception-safe, silent when `_meta` absent. Wired into `server.py:call_tool` with a single line.

**Public audit doc**: `docs/MCP_2026_SPEC_READINESS.md`. Documents which spec changes we handle, which are logged, which are deferred, and why the `not_yet` rows exist (gateway routing risk, unlocked response shapes, etc.). Doc and `READINESS_STATE` stay in sync under test.

## Why not more

- **Header emission** touches gateway routing. Guessed-wrong shape silently misroutes at load balancers.
- **`server/discover`** is additive but response body isn't locked yet. Ship after final spec — clean landing, no re-work.
- **`InputRequiredResult`** is a no-op until we have a tool that elicits mid-call user input. None exist in the 27-tool surface today.

Backward compatibility with 2025-03-26 spec preserved unconditionally. `list_tools`, `call_tool`, and every tool schema are byte-identical to v0.12.10.

## Test plan

- [x] 15 new tests in `tests/test_v01211_spec_readiness.py`
- [x] All five `READINESS_STATE` rows present with the states this patch locks (drift detector)
- [x] `extract_meta` returns mapping / None / None+warning by input shape
- [x] `log_meta_if_present` silent when absent, logs known+unknown when present, never raises
- [x] Call site in `server.py` calls `log_meta_if_present`
- [x] `KNOWN_META_KEYS` locked to the three RC keys
- [x] Audit doc exists, covers every row, mentions the 2026-07-28 date
- [x] Full suite: 624 pass (was 609; +15)
- [x] Contradictions benchmark: 105/105